### PR TITLE
fix: unblock docs deploy and release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,5 +46,5 @@ jobs:
           title: "chore: release packages"
           createGithubReleases: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/app/components/TheLanding.vue
+++ b/docs/app/components/TheLanding.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getHighlighter, bundledThemes } from "shiki";
+import { codeToHtml } from "shiki";
 import { usePreferredDark } from "@vueuse/core";
 
 const shikiLightTheme = "catppuccin-latte";
@@ -67,28 +67,23 @@ const rawResourceCode = [
   "})",
 ].join("\n");
 
-const highlighter = await getHighlighter({
-  themes: [bundledThemes[shikiLightTheme], bundledThemes[shikiDarkTheme]],
-  langs: ["ts"],
-});
-
 const heroHtmlLight = stripOuterCode(
-  highlighter.codeToHtml(rawHeroCode, { lang: "ts", theme: shikiLightTheme }),
+  await codeToHtml(rawHeroCode, { lang: "ts", theme: shikiLightTheme }),
 );
 const heroHtmlDark = stripOuterCode(
-  highlighter.codeToHtml(rawHeroCode, { lang: "ts", theme: shikiDarkTheme }),
+  await codeToHtml(rawHeroCode, { lang: "ts", theme: shikiDarkTheme }),
 );
 const resourceHtmlLight = stripOuterCode(
-  highlighter.codeToHtml(rawResourceCode, { lang: "ts", theme: shikiLightTheme }),
+  await codeToHtml(rawResourceCode, { lang: "ts", theme: shikiLightTheme }),
 );
 const resourceHtmlDark = stripOuterCode(
-  highlighter.codeToHtml(rawResourceCode, { lang: "ts", theme: shikiDarkTheme }),
+  await codeToHtml(rawResourceCode, { lang: "ts", theme: shikiDarkTheme }),
 );
 const requestHtmlLight = stripOuterCode(
-  highlighter.codeToHtml(rawRequestCode, { lang: "ts", theme: shikiLightTheme }),
+  await codeToHtml(rawRequestCode, { lang: "ts", theme: shikiLightTheme }),
 );
 const requestHtmlDark = stripOuterCode(
-  highlighter.codeToHtml(rawRequestCode, { lang: "ts", theme: shikiDarkTheme }),
+  await codeToHtml(rawRequestCode, { lang: "ts", theme: shikiDarkTheme }),
 );
 
 const colorMode = useColorMode();


### PR DESCRIPTION
## Summary

- fixes the docs landing Shiki usage so the docs/Vercel build stops failing
- lets the release workflow use `RELEASE_GITHUB_TOKEN` when the default Actions token cannot create PRs

## Notes

- `RELEASE_GITHUB_TOKEN` has been configured as a repo secret
- this should allow the Changesets release PR to be created or updated automatically after merge