### PR TITLE
fix: pass npm token to release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,4 +47,5 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `NPM_TOKEN` to the release workflow environment so `changesets/action` uses the npm token instead of falling back to interactive trusted publishing.

## Why

The previous release run reached publish, but failed with `EOTP` because Changesets reported `No NPM_TOKEN found` even though `NODE_AUTH_TOKEN` was set.