### PR TITLE
fix(monorepo): stabilize playground release prep

### DIFF
--- a/.changeset/bright-lamps-vanish.md
+++ b/.changeset/bright-lamps-vanish.md
@@ -1,0 +1,6 @@
+---
+"drizzle-resource": patch
+"@drizzle-resource/core": patch
+---
+
+Fix SQLite compatibility in aggregate queries and improve the docs playground with a pre-seeded database, default facet showcase, and faster nested OR demos.

--- a/bun.lock
+++ b/bun.lock
@@ -16,14 +16,19 @@
     "docs": {
       "name": "@drizzle-resource/docs",
       "dependencies": {
+        "@faker-js/faker": "^10.4.0",
         "better-sqlite3": "^12.5.0",
         "docus": "latest",
         "drizzle-orm": "1.0.0-beta.16-ea816b6",
         "drizzle-resource": "workspace:*",
         "nuxt": "^4.2.2",
         "nuxt-content-twoslash": "^0.4.0",
+        "sql.js": "^1.14.1",
         "zod": "^4.3.6",
         "zod-to-json-schema": "^3.24.6",
+      },
+      "devDependencies": {
+        "@types/sql.js": "^1.4.11",
       },
     },
     "packages/core": {
@@ -291,6 +296,8 @@
     "@eslint/object-schema": ["@eslint/object-schema@3.0.3", "", {}, "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.6.1", "", { "dependencies": { "@eslint/core": "^1.1.1", "levn": "^0.4.1" } }, "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ=="],
+
+    "@faker-js/faker": ["@faker-js/faker@10.4.0", "", {}, "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw=="],
 
     "@fastify/accept-negotiator": ["@fastify/accept-negotiator@2.0.1", "", {}, "sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ=="],
 
@@ -1038,6 +1045,8 @@
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
+    "@types/emscripten": ["@types/emscripten@1.41.5", "", {}, "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q=="],
+
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -1060,13 +1069,15 @@
 
     "@types/mssql": ["@types/mssql@9.1.11", "", { "dependencies": { "@types/node": "*", "tarn": "^3.0.1", "tedious": "*" } }, "sha512-vcujgrDbDezCxNDO4KY6gjwduLYOKfrexpRUwhoysRvcXZ3+IgZ/PMYFDgh8c3cQIxZ6skAwYo+H6ibMrBWPjQ=="],
 
-    "@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@types/parse-path": ["@types/parse-path@7.1.0", "", { "dependencies": { "parse-path": "*" } }, "sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q=="],
 
     "@types/readable-stream": ["@types/readable-stream@4.0.23", "", { "dependencies": { "@types/node": "*" } }, "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig=="],
 
     "@types/resolve": ["@types/resolve@1.20.2", "", {}, "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="],
+
+    "@types/sql.js": ["@types/sql.js@1.4.11", "", { "dependencies": { "@types/emscripten": "*", "@types/node": "*" } }, "sha512-QXIx38p2ZThJaK9vP5ZdqdlRe1FG9I8SmCZOS7FHfB/2qPAjZwkL7/vlfPg6N/oWHuuOaGg/P/IRwfP2W0kWVQ=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -2634,6 +2645,8 @@
 
     "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
+    "sql.js": ["sql.js@1.14.1", "", {}, "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A=="],
+
     "srvx": ["srvx@0.11.13", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-oknN6qduuMPafxKtHucUeG32Q963pjriA5g3/Bl05cwEsUe5VVbIU4qR9LrALHbipSCyBe+VmfDGGydqazDRkw=="],
 
     "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
@@ -2984,6 +2997,8 @@
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
+    "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
+
     "@manypkg/find-root/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
     "@manypkg/get-packages/@changesets/types": ["@changesets/types@4.1.0", "", {}, "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw=="],
@@ -3066,7 +3081,7 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@types/readable-stream/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+    "@types/mssql/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
@@ -3101,8 +3116,6 @@
     "c12/giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
 
     "c12/rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
-
-    "chrome-launcher/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "chrome-launcher/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -3233,8 +3246,6 @@
     "tar-stream/bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
     "tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
-
-    "tedious/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
@@ -3505,8 +3516,6 @@
     "lazystream/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "mlly/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
-
-    "mssql/tedious/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "mssql/tedious/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 

--- a/docs/app/pages/playground.vue
+++ b/docs/app/pages/playground.vue
@@ -1,0 +1,680 @@
+<script setup lang="ts">
+import type { TableColumn, TabsItem } from "@nuxt/ui";
+import type { PlaygroundRequest } from "../utils/playground-request";
+import type { createPlaygroundClient } from "../utils/playground.client";
+
+import {
+  basePlaygroundRequest,
+  defaultPlaygroundRequest,
+  formatValidationError,
+  playgroundContractSnippet,
+  playgroundContext,
+  playgroundRequestSchema,
+  playgroundSeedSummary,
+  playgroundTablesSnippet,
+} from "../utils/playground-request";
+
+definePageMeta({
+  layout: "default",
+  footer: false,
+});
+
+useSeo({
+  title: "Playground",
+  description:
+    "Edit a real drizzle-resource request, validate it live, and run it against an in-browser SQLite database powered by sql.js and Drizzle.",
+  type: "website",
+});
+
+const requestText = ref(JSON.stringify(basePlaygroundRequest, null, 2));
+const isBooting = ref(true);
+const isRunning = ref(false);
+const bootMessage = ref("Loading playground database…");
+const bootstrapError = ref<string | null>(null);
+const runtimeError = ref<string | null>(null);
+const validationError = ref<string | null>(null);
+type PlaygroundClient = Awaited<ReturnType<typeof createPlaygroundClient>>;
+type PlaygroundResult = Awaited<ReturnType<PlaygroundClient["run"]>>;
+type PlaygroundRow = PlaygroundResult["rows"][number];
+
+const lastAppliedRequest = ref<PlaygroundRequest | null>(null);
+const lastRunAt = ref<string | null>(null);
+const result = shallowRef<PlaygroundResult | null>(null);
+const playground = shallowRef<PlaygroundClient | null>(null);
+
+const mobileTab = ref<"editor" | "results">("editor");
+const editorTab = ref<"request" | "contract" | "tables">("request");
+
+const examples = [
+  {
+    label: "Base",
+    value: basePlaygroundRequest,
+  },
+  {
+    label: "Pending + Processing",
+    value: defaultPlaygroundRequest,
+  },
+  {
+    label: "Laptop Search",
+    value: {
+      ...basePlaygroundRequest,
+      search: {
+        value: "laptop",
+        fields: [],
+      },
+    } satisfies PlaygroundRequest,
+  },
+  {
+    label: "Nested OR Group",
+    value: {
+      ...basePlaygroundRequest,
+      filters: [
+        {
+          type: "group",
+          combinator: "or",
+          children: [
+            {
+              type: "condition",
+              key: "status",
+              operator: "is",
+              value: "pending",
+            },
+            {
+              type: "condition",
+              key: "orderLines.product.category",
+              operator: "is",
+              value: "audio",
+            },
+          ],
+        },
+      ],
+      facets: [
+        { key: "status", mode: "exclude-self", limit: 10 },
+        { key: "orderLines.product.category", mode: "exclude-self", limit: 10 },
+      ],
+    } satisfies PlaygroundRequest,
+  },
+] as const;
+
+const PRODUCTS_VISIBLE = 2;
+
+const statusColor: Record<string, "warning" | "primary" | "success" | "error" | "neutral"> = {
+  pending: "warning",
+  processing: "primary",
+  shipped: "success",
+  cancelled: "error",
+};
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+
+const tableColumns: TableColumn<PlaygroundRow>[] = [
+  { accessorKey: "reference", header: "Reference" },
+  { accessorKey: "status", header: "Status" },
+  { accessorKey: "customer", header: "Customer", cell: ({ row }) => row.original.customer.name },
+  { accessorKey: "orderLines", header: "Products" },
+  {
+    accessorKey: "totalAmount",
+    header: "Total",
+    cell: ({ row }) => currencyFormatter.format(row.original.totalAmount),
+  },
+  {
+    accessorKey: "createdAt",
+    header: "Created",
+    cell: ({ row }) => dateFormatter.format(new Date(row.original.createdAt)),
+  },
+];
+
+const rows = computed(() => result.value?.rows ?? []);
+const facets = computed(() => result.value?.facets ?? []);
+const rowCount = computed(() => result.value?.rowCount ?? 0);
+const activeFilterCount = computed(() => lastAppliedRequest.value?.filters.length ?? 0);
+
+const sampleOptions = computed(() =>
+  examples.map((example) => ({
+    label: example.label,
+    value: example.label,
+  })),
+);
+
+const selectedExample = ref<(typeof examples)[number]["label"]>(examples[0]!.label);
+
+const editorTabs = [
+  {
+    label: "Request",
+    value: "request",
+    icon: "i-lucide-file-json-2",
+    slot: "request",
+  },
+  {
+    label: "Contract",
+    value: "contract",
+    icon: "i-lucide-file-code-2",
+    slot: "contract",
+  },
+  {
+    label: "Tables",
+    value: "tables",
+    icon: "i-lucide-database",
+    slot: "tables",
+  },
+] satisfies TabsItem[];
+
+const contractMarkdown = `\`\`\`ts [orders.resource.ts]
+${playgroundContractSnippet}
+\`\`\``;
+
+const tablesMarkdown = `\`\`\`ts [schema.ts]
+${playgroundTablesSnippet}
+\`\`\``;
+
+let runTimer: ReturnType<typeof setTimeout> | undefined;
+
+function setExample(label: string) {
+  const example = examples.find((entry) => entry.label === label) ?? examples[0]!;
+  selectedExample.value = example.label;
+  requestText.value = JSON.stringify(example.value, null, 2);
+}
+
+function parseRequestText() {
+  try {
+    const parsed = JSON.parse(requestText.value);
+    const validated = playgroundRequestSchema.safeParse(parsed);
+
+    if (!validated.success) {
+      return {
+        data: null,
+        error: formatValidationError(validated.error),
+      };
+    }
+
+    return {
+      data: validated.data,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      data: null,
+      error: formatValidationError(error as Error),
+    };
+  }
+}
+
+async function runRequest(request: PlaygroundRequest) {
+  if (!playground.value) return;
+
+  isRunning.value = true;
+  runtimeError.value = null;
+  console.debug("[playground-page] applying request");
+
+  try {
+    const nextResult = await playground.value.run(request);
+    result.value = nextResult;
+    lastAppliedRequest.value = request;
+    lastRunAt.value = new Intl.DateTimeFormat("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    }).format(new Date());
+  } catch (error) {
+    runtimeError.value = formatValidationError(error as Error);
+    console.error("[playground-page] request failed", error);
+  } finally {
+    isRunning.value = false;
+  }
+}
+
+watch(
+  requestText,
+  () => {
+    clearTimeout(runTimer);
+
+    const parsed = parseRequestText();
+    validationError.value = parsed.error;
+
+    if (!parsed.data || !playground.value) {
+      return;
+    }
+
+    runTimer = setTimeout(() => {
+      void runRequest(parsed.data);
+    }, 250);
+  },
+  { immediate: false },
+);
+
+onMounted(async () => {
+  try {
+    bootMessage.value = "Loading SQL engine…";
+    const { createPlaygroundClient } = await import("../utils/playground.client");
+    bootMessage.value = "Opening pre-seeded playground database…";
+    playground.value = await createPlaygroundClient();
+
+    bootMessage.value = "Running initial query…";
+    const parsed = parseRequestText();
+    validationError.value = parsed.error;
+
+    if (parsed.data) {
+      await runRequest(parsed.data);
+    }
+  } catch (error) {
+    bootstrapError.value = formatValidationError(error as Error);
+    console.error("[playground-page] bootstrap failed", error);
+  } finally {
+    isBooting.value = false;
+    bootMessage.value = "Playground ready";
+  }
+});
+
+onBeforeUnmount(() => {
+  clearTimeout(runTimer);
+  playground.value?.dispose();
+});
+</script>
+
+<template>
+  <div class="flex h-[calc(100svh-var(--ui-header-height,64px))] flex-col overflow-hidden">
+    <!-- Top bar -->
+    <div
+      class="flex shrink-0 items-center gap-3 border-b border-default bg-default/80 px-4 py-2.5 backdrop-blur"
+    >
+      <UBadge color="primary" variant="soft" size="sm">Browser Playground</UBadge>
+
+      <div class="hidden items-center gap-2 text-xs text-toned sm:flex">
+        <span>
+          {{ playgroundSeedSummary.orders.toLocaleString() }} orders ·
+          {{ playgroundSeedSummary.customers.toLocaleString() }} customers ·
+          {{ playgroundSeedSummary.products.toLocaleString() }} products
+        </span>
+        <UBadge color="neutral" variant="subtle" size="sm">
+          orgId: {{ playgroundContext.orgId }}
+        </UBadge>
+      </div>
+
+      <div class="ml-auto flex items-center gap-2">
+        <div v-if="isBooting || isRunning" class="flex items-center gap-1.5">
+          <span class="size-1.5 animate-pulse rounded-full bg-primary" />
+          <span class="text-xs text-primary">{{ isBooting ? "Booting…" : "Running…" }}</span>
+        </div>
+        <div v-else-if="!validationError" class="flex items-center gap-1.5">
+          <span class="size-1.5 rounded-full bg-success" />
+          <span class="text-xs text-success">Valid</span>
+        </div>
+        <div v-else-if="validationError" class="flex items-center gap-1.5">
+          <span class="size-1.5 rounded-full bg-error" />
+          <span class="text-xs text-error">Invalid</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Mobile tab bar -->
+    <div class="flex shrink-0 border-b border-default sm:hidden">
+      <button
+        v-for="tab in [
+          { id: 'editor', label: 'Editor', icon: 'i-lucide-code-2' },
+          { id: 'results', label: 'Results', icon: 'i-lucide-table-2' },
+        ]"
+        :key="tab.id"
+        class="flex flex-1 items-center justify-center gap-1.5 px-4 py-2.5 text-sm font-medium transition-colors"
+        :class="
+          mobileTab === tab.id
+            ? 'border-b-2 border-primary text-primary'
+            : 'text-toned hover:text-default'
+        "
+        @click="mobileTab = tab.id as 'editor' | 'results'"
+      >
+        <UIcon :name="tab.icon" class="size-4" />
+        {{ tab.label }}
+      </button>
+    </div>
+
+    <!-- Split body -->
+    <div class="flex min-h-0 flex-1">
+      <!-- Editor panel -->
+      <div
+        :class="[
+          'flex flex-col border-r border-default',
+          mobileTab !== 'editor' ? 'hidden sm:flex' : 'flex',
+          'w-full sm:w-[400px] lg:w-[460px] xl:w-[500px] shrink-0',
+        ]"
+      >
+        <UTabs
+          v-model="editorTab"
+          :items="editorTabs"
+          size="sm"
+          variant="pill"
+          color="neutral"
+          class="flex min-h-0 flex-1 flex-col"
+          :ui="{
+            root: 'min-h-0 flex flex-1 flex-col',
+            list: 'rounded-none',
+            content: 'min-h-0 flex-1',
+          }"
+        >
+          <template #request>
+            <div class="flex h-full min-h-0 flex-col">
+              <div
+                class="grid shrink-0 grid-cols-[minmax(0,1fr)_auto] gap-3 border-b border-default p-4"
+              >
+                <USelectMenu
+                  v-model="selectedExample"
+                  value-key="value"
+                  label-key="label"
+                  :items="sampleOptions"
+                  :search-input="false"
+                  size="sm"
+                  class="w-full"
+                  @update:model-value="setExample"
+                />
+                <UButton
+                  color="neutral"
+                  icon="i-lucide-rotate-ccw"
+                  size="sm"
+                  @click="setExample(selectedExample)"
+                >
+                  Reset
+                </UButton>
+              </div>
+
+              <div class="min-h-0 flex-1 overflow-hidden">
+                <UTextarea
+                  v-model="requestText"
+                  :color="validationError ? 'error' : 'neutral'"
+                  :variant="validationError ? 'outline' : 'none'"
+                  size="sm"
+                  :rows="26"
+                  :autoresize="false"
+                  spellcheck="false"
+                  class="h-full min-h-0 w-full"
+                  :ui="{
+                    root: 'flex h-full min-h-0 w-full',
+                    base: 'flex-1 h-full min-h-0 w-full rounded-none',
+                  }"
+                  placeholder="Paste a QueryRequest payload here"
+                />
+              </div>
+
+              <div v-if="validationError" class="shrink-0 border-t border-default">
+                <UAlert
+                  color="error"
+                  variant="soft"
+                  title="Invalid request"
+                  :description="validationError"
+                  size="sm"
+                  class="w-full rounded-none"
+                />
+              </div>
+
+              <div v-if="bootstrapError" class="shrink-0 border-t border-default">
+                <UAlert
+                  color="error"
+                  variant="soft"
+                  title="Playground failed to boot"
+                  :description="bootstrapError"
+                  size="sm"
+                  class="w-full rounded-none"
+                />
+              </div>
+            </div>
+          </template>
+
+          <template #contract>
+            <div class="flex h-full min-h-0 flex-col">
+              <div class="min-h-0 flex-1 overflow-auto px-4 pb-4">
+                <article class="prose prose-sm max-w-none [&_pre]:mt-0">
+                  <MDC :value="contractMarkdown" tag="div" />
+                </article>
+              </div>
+            </div>
+          </template>
+
+          <template #tables>
+            <div class="flex h-full min-h-0 flex-col">
+              <div class="min-h-0 flex-1 overflow-auto px-4 pb-4">
+                <article class="prose prose-sm max-w-none [&_pre]:mt-0">
+                  <MDC :value="tablesMarkdown" tag="div" />
+                </article>
+              </div>
+            </div>
+          </template>
+        </UTabs>
+      </div>
+
+      <!-- Results panel -->
+      <div
+        :class="[
+          'min-h-0 flex-1 overflow-y-auto',
+          mobileTab !== 'results' ? 'hidden sm:block' : 'block',
+        ]"
+      >
+        <div class="space-y-4 p-4">
+          <!-- Stats row -->
+          <div class="grid grid-cols-2 gap-3 lg:grid-cols-4">
+            <div
+              v-for="stat in [
+                { label: 'Matching rows', value: rowCount.toLocaleString() },
+                { label: 'Page size', value: rows.length.toLocaleString() },
+                { label: 'Active filters', value: activeFilterCount.toLocaleString() },
+                { label: 'Last run', value: lastRunAt ?? '--:--:--', mono: true },
+              ]"
+              :key="stat.label"
+              class="rounded-xl border border-default bg-default px-4 py-3"
+            >
+              <p class="text-xs text-toned">{{ stat.label }}</p>
+              <p
+                class="mt-1 text-xl font-semibold text-highlighted"
+                :class="stat.mono ? 'font-mono text-base' : ''"
+              >
+                {{ stat.value }}
+              </p>
+            </div>
+          </div>
+
+          <!-- Runtime error -->
+          <UAlert
+            v-if="runtimeError"
+            color="warning"
+            variant="soft"
+            title="Runtime constraint"
+            :description="runtimeError"
+          />
+
+          <UCard
+            v-if="isBooting"
+            class="border-primary/20 bg-primary/5"
+            :ui="{ body: 'p-5 sm:p-5' }"
+          >
+            <div class="flex items-start gap-4">
+              <div
+                class="mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10"
+              >
+                <UIcon name="i-lucide-database-zap" class="size-5 animate-pulse text-primary" />
+              </div>
+              <div class="space-y-1">
+                <p class="text-sm font-medium text-highlighted">Booting playground</p>
+                <p class="text-sm text-toned">{{ bootMessage }}</p>
+                <p class="text-xs text-toned">
+                  Loading the pre-seeded SQLite file and warming the real drizzle-resource query
+                  engine.
+                </p>
+              </div>
+            </div>
+          </UCard>
+
+          <!-- Rows table -->
+          <UCard :ui="{ body: 'p-0 sm:p-0' }">
+            <template #header>
+              <div class="flex items-center justify-between gap-3">
+                <div>
+                  <p class="text-sm font-medium text-highlighted">Rows</p>
+                  <p class="text-xs text-toned">
+                    Showing {{ rows.length }} row{{ rows.length === 1 ? "" : "s" }} from the current
+                    page
+                  </p>
+                </div>
+                <UBadge color="neutral" variant="subtle" size="sm">
+                  {{
+                    lastAppliedRequest ? "Last valid request applied" : "Waiting for valid request"
+                  }}
+                </UBadge>
+              </div>
+            </template>
+
+            <div class="table-scroll max-h-[400px] overflow-y-auto">
+              <UTable
+                :data="rows"
+                :columns="tableColumns"
+                :loading="isBooting || isRunning"
+                empty="No rows match the current request."
+                :ui="{ thead: 'sticky top-0 z-10 bg-default' }"
+              >
+                <template #reference-cell="{ row }">
+                  <span class="font-mono text-xs text-highlighted">
+                    {{ row.original.reference }}
+                  </span>
+                </template>
+
+                <template #status-cell="{ row }">
+                  <UBadge
+                    :color="statusColor[row.original.status] ?? 'neutral'"
+                    variant="subtle"
+                    size="sm"
+                    class="capitalize"
+                  >
+                    {{ row.original.status }}
+                  </UBadge>
+                </template>
+
+                <template #orderLines-cell="{ row }">
+                  <div class="flex flex-wrap items-center gap-1">
+                    <UBadge
+                      v-for="line in row.original.orderLines.slice(0, PRODUCTS_VISIBLE)"
+                      :key="line.id"
+                      color="neutral"
+                      variant="subtle"
+                      size="sm"
+                      class="max-w-[140px] truncate"
+                    >
+                      {{ line.product.name }}
+                    </UBadge>
+
+                    <UTooltip
+                      v-if="row.original.orderLines.length > PRODUCTS_VISIBLE"
+                      :content="{
+                        align: 'start',
+                        side: 'top',
+                      }"
+                    >
+                      <UBadge color="neutral" variant="soft" size="sm">
+                        +{{ row.original.orderLines.length - PRODUCTS_VISIBLE }}
+                      </UBadge>
+                      <template #content>
+                        <ul class="space-y-0.5 text-xs">
+                          <li
+                            v-for="line in row.original.orderLines.slice(PRODUCTS_VISIBLE)"
+                            :key="line.id"
+                          >
+                            {{ line.product.name }}
+                          </li>
+                        </ul>
+                      </template>
+                    </UTooltip>
+
+                    <span v-if="row.original.orderLines.length === 0" class="text-xs text-toned"
+                      >—</span
+                    >
+                  </div>
+                </template>
+              </UTable>
+            </div>
+          </UCard>
+
+          <!-- Facets -->
+          <div class="space-y-3">
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <p class="text-sm font-medium text-highlighted">Facet buckets</p>
+                <p class="text-xs text-toned">
+                  Live aggregation results returned alongside the current query.
+                </p>
+              </div>
+              <UBadge color="neutral" variant="subtle" size="sm">
+                {{ facets.length }} facet{{ facets.length === 1 ? "" : "s" }}
+              </UBadge>
+            </div>
+
+            <div v-if="facets.length > 0" class="grid gap-3 sm:grid-cols-2">
+              <UCard v-for="facet in facets" :key="facet.key">
+                <template #header>
+                  <div class="flex items-center justify-between gap-2">
+                    <p class="text-sm font-medium text-highlighted">{{ facet.key }}</p>
+                    <UBadge color="neutral" variant="subtle" size="sm">
+                      {{ facet.total ?? facet.options.length }} bucket{{
+                        (facet.total ?? facet.options.length) === 1 ? "" : "s"
+                      }}
+                    </UBadge>
+                  </div>
+                </template>
+
+                <div class="space-y-2">
+                  <div
+                    v-for="option in facet.options"
+                    :key="`${facet.key}-${String(option.value)}`"
+                    class="flex items-center justify-between gap-3"
+                  >
+                    <span class="truncate text-sm text-highlighted">{{ option.value }}</span>
+                    <UBadge color="neutral" variant="soft" size="sm">{{ option.count }}</UBadge>
+                  </div>
+                  <p v-if="facet.options.length === 0" class="text-sm text-toned">
+                    No options for the current request.
+                  </p>
+                </div>
+              </UCard>
+            </div>
+
+            <UAlert
+              v-else
+              color="neutral"
+              variant="soft"
+              title="No facets requested"
+              description="Add entries to request.facets to showcase live bucket counts in the playground."
+            />
+          </div>
+
+          <!-- Last applied request -->
+          <UCard>
+            <template #header>
+              <div class="flex items-center justify-between gap-3">
+                <div>
+                  <p class="text-sm font-medium text-highlighted">Last applied request</p>
+                  <p class="text-xs text-toned">The most recent valid payload that actually ran.</p>
+                </div>
+                <UBadge color="neutral" variant="subtle" size="sm">
+                  {{
+                    lastAppliedRequest?.pagination.pageSize ??
+                    basePlaygroundRequest.pagination.pageSize
+                  }}
+                  per page
+                </UBadge>
+              </div>
+            </template>
+
+            <pre
+              class="max-h-64 overflow-y-auto rounded-lg bg-muted text-xs leading-6 text-toned"
+              >{{ JSON.stringify(lastAppliedRequest ?? basePlaygroundRequest, null, 2) }}</pre
+            >
+          </UCard>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/docs/app/utils/playground-request.ts
+++ b/docs/app/utils/playground-request.ts
@@ -1,0 +1,302 @@
+import type { QueryRequest } from "drizzle-resource";
+
+import { z } from "zod";
+
+export const playgroundSeedSummary = {
+  customers: 320,
+  orders: 10_000,
+  products: 180,
+};
+
+// Nuxt auto-import scanning mistakenly registers `query.search` from this file as a top-level export.
+export const search = undefined;
+
+const filterConditionSchema = z.object({
+  type: z.literal("condition"),
+  key: z.string().min(1),
+  operator: z.enum([
+    "contains",
+    "is",
+    "isAnyOf",
+    "isNot",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "between",
+    "before",
+    "after",
+  ]),
+  value: z.unknown(),
+});
+
+type FilterNode =
+  | z.infer<typeof filterConditionSchema>
+  | {
+      type: "group";
+      combinator: "and" | "or";
+      children: FilterNode[];
+    };
+
+const filterNodeSchema: z.ZodType<FilterNode> = z.lazy(() =>
+  z.union([
+    filterConditionSchema,
+    z.object({
+      type: z.literal("group"),
+      combinator: z.enum(["and", "or"]),
+      children: z.array(filterNodeSchema),
+    }),
+  ]),
+);
+
+export const playgroundRequestSchema = z.object({
+  context: z.record(z.string(), z.unknown()),
+  pagination: z.object({
+    pageIndex: z.number().int().min(1),
+    pageSize: z.number().int().min(1).max(100),
+  }),
+  sorting: z.array(
+    z.object({
+      key: z.string().min(1),
+      dir: z.enum(["asc", "desc"]),
+    }),
+  ),
+  search: z.object({
+    value: z.string(),
+    fields: z.array(z.string().min(1)),
+  }),
+  filters: z.array(filterNodeSchema),
+  facets: z
+    .array(
+      z.object({
+        key: z.string().min(1),
+        mode: z.enum(["exclude-self", "include-self"]).optional(),
+        search: z.string().optional(),
+        limit: z.number().int().min(1).max(100).optional(),
+        cursor: z.string().nullable().optional(),
+      }),
+    )
+    .optional(),
+}) satisfies z.ZodType<QueryRequest>;
+
+export type PlaygroundRequest = z.infer<typeof playgroundRequestSchema>;
+
+export const basePlaygroundRequest: QueryRequest = {
+  context: {},
+  pagination: {
+    pageIndex: 1,
+    pageSize: 25,
+  },
+  sorting: [{ key: "createdAt", dir: "desc" }],
+  search: {
+    value: "",
+    fields: [],
+  },
+  filters: [],
+  facets: [
+    {
+      key: "status",
+      mode: "exclude-self",
+      limit: 10,
+    },
+    {
+      key: "orderLines.product.category",
+      mode: "exclude-self",
+      limit: 10,
+    },
+  ],
+};
+
+export const defaultPlaygroundRequest: QueryRequest = {
+  context: {},
+  pagination: {
+    pageIndex: 1,
+    pageSize: 25,
+  },
+  sorting: [{ key: "createdAt", dir: "desc" }],
+  search: {
+    value: "",
+    fields: [],
+  },
+  filters: [
+    {
+      type: "condition",
+      key: "status",
+      operator: "isAnyOf",
+      value: ["pending", "processing"],
+    },
+  ],
+  facets: [
+    {
+      key: "status",
+      mode: "exclude-self",
+      limit: 10,
+    },
+    {
+      key: "orderLines.product.category",
+      mode: "exclude-self",
+      limit: 10,
+    },
+  ],
+};
+
+export const playgroundContext = {
+  orgId: "acme",
+};
+
+export const playgroundTableDefs = [
+  {
+    name: "orders",
+    columns: [
+      { name: "id", type: "text", primaryKey: true, notNull: true },
+      { name: "created_at", type: "text", notNull: true },
+      { name: "customer_id", type: "text", notNull: true, fk: "customers.id" },
+      { name: "deleted_at", type: "text" },
+      { name: "reference", type: "text", notNull: true },
+      { name: "status", type: "text", notNull: true },
+      { name: "total_amount", type: "integer", notNull: true },
+    ],
+  },
+  {
+    name: "customers",
+    columns: [
+      { name: "id", type: "text", primaryKey: true, notNull: true },
+      { name: "name", type: "text", notNull: true },
+      { name: "org_id", type: "text", notNull: true },
+    ],
+  },
+  {
+    name: "products",
+    columns: [
+      { name: "id", type: "text", primaryKey: true, notNull: true },
+      { name: "category", type: "text", notNull: true },
+      { name: "label", type: "text", notNull: true },
+      { name: "name", type: "text", notNull: true },
+      { name: "sku", type: "text", notNull: true },
+    ],
+  },
+  {
+    name: "order_lines",
+    columns: [
+      { name: "id", type: "text", primaryKey: true, notNull: true },
+      { name: "order_id", type: "text", notNull: true, fk: "orders.id" },
+      { name: "product_id", type: "text", notNull: true, fk: "products.id" },
+      { name: "quantity", type: "integer", notNull: true },
+    ],
+  },
+] as const;
+
+export const playgroundContractDef = {
+  resource: "orders",
+  relations: {
+    customer: { type: "one", table: "customers" },
+    orderLines: {
+      type: "many",
+      table: "order_lines",
+      with: { product: { type: "one", table: "products" } },
+    },
+  },
+  query: {
+    defaults: {
+      pagination: { pageSize: 5 },
+      sort: [{ key: "createdAt", dir: "desc" }],
+    },
+    scope: 'filters.is("customer.orgId", context.orgId)',
+    facets: {
+      allowed: ["status", "customer.name", "orderLines.product.category"],
+    },
+    filters: {
+      disabled: ["deletedAt"],
+      hidden: [] as string[],
+    },
+    search: {
+      allowed: ["reference", "customer.name", "orderLines.product.name", "orderLines.product.sku"],
+      defaults: ["reference", "customer.name"],
+    },
+    sort: {
+      disabled: ["orderLines.product.name"],
+    },
+  },
+} as const;
+
+export const playgroundTablesSnippet = `import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const customers = sqliteTable("customers", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  orgId: text("org_id").notNull(),
+});
+
+export const products = sqliteTable("products", {
+  id: text("id").primaryKey(),
+  category: text("category").notNull(),
+  label: text("label").notNull(),
+  name: text("name").notNull(),
+  sku: text("sku").notNull(),
+});
+
+export const orders = sqliteTable("orders", {
+  id: text("id").primaryKey(),
+  createdAt: text("created_at").notNull(),
+  customerId: text("customer_id").notNull(),
+  deletedAt: text("deleted_at"),
+  reference: text("reference").notNull(),
+  status: text("status").notNull(),
+  totalAmount: integer("total_amount").notNull(),
+});
+
+export const orderLines = sqliteTable("order_lines", {
+  id: text("id").primaryKey(),
+  orderId: text("order_id").notNull(),
+  productId: text("product_id").notNull(),
+  quantity: integer("quantity").notNull(),
+});`;
+
+export const playgroundContractSnippet = `export const ordersResource = engine.defineResource("orders", {
+  relations: {
+    customer: true,
+    orderLines: {
+      with: {
+        product: true,
+      },
+    },
+  },
+  query: {
+    defaults: {
+      pagination: { pageSize: 5 },
+    },
+    scope: (filters, context) => filters.is("customer.orgId", context.orgId),
+    search: {
+      allowed: [
+        "reference",
+        "customer.name",
+        "orderLines.product.name",
+        "orderLines.product.sku",
+      ],
+      defaults: ["reference", "customer.name"],
+    },
+    filters: {
+      disabled: ["deletedAt"],
+    },
+    sort: {
+      defaults: [{ key: "createdAt", dir: "desc" }],
+      disabled: ["orderLines.product.name"],
+    },
+    facets: {
+      allowed: ["status", "customer.name", "orderLines.product.category"],
+    },
+  },
+});`;
+
+export function formatValidationError(error: z.ZodError | Error) {
+  if (error instanceof z.ZodError) {
+    return error.issues
+      .map((issue) => {
+        const path = issue.path.length > 0 ? issue.path.join(".") : "request";
+        return `${path}: ${issue.message}`;
+      })
+      .join("\n");
+  }
+
+  return error.message;
+}

--- a/docs/app/utils/playground.client.ts
+++ b/docs/app/utils/playground.client.ts
@@ -1,0 +1,307 @@
+import { asc, defineRelationsPart, eq, inArray } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/sql-js";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { createQueryEngine } from "drizzle-resource";
+import { createQueryFilterBuilder } from "drizzle-resource";
+import initSqlJs from "sql.js";
+import type { Database as SqlJsDatabase } from "sql.js";
+import sqlWasmUrl from "sql.js/dist/sql-wasm.wasm?url";
+import playgroundDbUrl from "../assets/playground.sqlite?url";
+
+import { playgroundContext } from "./playground-request";
+import type { PlaygroundRequest } from "./playground-request";
+
+const customers = sqliteTable("customers", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  orgId: text("org_id").notNull(),
+});
+
+const products = sqliteTable("products", {
+  id: text("id").primaryKey(),
+  category: text("category").notNull(),
+  label: text("label").notNull(),
+  name: text("name").notNull(),
+  sku: text("sku").notNull(),
+});
+
+const orders = sqliteTable("orders", {
+  id: text("id").primaryKey(),
+  createdAt: text("created_at").notNull(),
+  customerId: text("customer_id").notNull(),
+  deletedAt: text("deleted_at"),
+  reference: text("reference").notNull(),
+  status: text("status").notNull(),
+  totalAmount: integer("total_amount").notNull(),
+});
+
+const orderLines = sqliteTable("order_lines", {
+  id: text("id").primaryKey(),
+  orderId: text("order_id").notNull(),
+  productId: text("product_id").notNull(),
+  quantity: integer("quantity").notNull(),
+});
+
+const schema = {
+  customers,
+  orderLines,
+  orders,
+  products,
+};
+
+const relations = defineRelationsPart(
+  schema,
+  ({
+    customers: customersTable,
+    many,
+    one,
+    orderLines: orderLinesTable,
+    orders: ordersTable,
+    products: productsTable,
+  }) => ({
+    customers: {
+      orders: many.orders({
+        from: customersTable.id,
+        to: ordersTable.customerId,
+      }),
+    },
+    orders: {
+      customer: one.customers({
+        from: ordersTable.customerId,
+        optional: false,
+        to: customersTable.id,
+      }),
+      orderLines: many.orderLines({
+        from: ordersTable.id,
+        to: orderLinesTable.orderId,
+      }),
+    },
+    orderLines: {
+      order: one.orders({
+        from: orderLinesTable.orderId,
+        optional: false,
+        to: ordersTable.id,
+      }),
+      product: one.products({
+        from: orderLinesTable.productId,
+        optional: false,
+        to: productsTable.id,
+      }),
+    },
+    products: {
+      orderLines: many.orderLines({
+        from: productsTable.id,
+        to: orderLinesTable.productId,
+      }),
+    },
+  }),
+);
+
+async function loadDatabaseBytes(databaseUrl: string) {
+  console.debug("[playground] fetching pre-seeded database", { databaseUrl });
+  const response = await fetch(databaseUrl, { cache: "no-store" });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to load playground database (${response.status} ${response.statusText})`,
+    );
+  }
+
+  const buffer = await response.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+  console.debug("[playground] database bytes loaded", { byteLength: bytes.byteLength });
+  return bytes;
+}
+
+function definePlaygroundResource(sqlite: SqlJsDatabase) {
+  const db = drizzle(sqlite, { schema });
+
+  async function fetchRowsByIds(ids: unknown[]) {
+    const orderIds = ids.filter((id): id is string => typeof id === "string");
+
+    if (orderIds.length === 0) {
+      return [];
+    }
+
+    const joinedRows = await db
+      .select({
+        customerId: customers.id,
+        customerName: customers.name,
+        customerOrgId: customers.orgId,
+        lineId: orderLines.id,
+        orderCreatedAt: orders.createdAt,
+        orderDeletedAt: orders.deletedAt,
+        orderId: orders.id,
+        orderReference: orders.reference,
+        orderStatus: orders.status,
+        orderTotalAmount: orders.totalAmount,
+        productCategory: products.category,
+        productId: products.id,
+        productLabel: products.label,
+        productName: products.name,
+        productSku: products.sku,
+        quantity: orderLines.quantity,
+      })
+      .from(orders)
+      .innerJoin(customers, eq(orders.customerId, customers.id))
+      .leftJoin(orderLines, eq(orderLines.orderId, orders.id))
+      .leftJoin(products, eq(products.id, orderLines.productId))
+      .where(inArray(orders.id, orderIds))
+      .orderBy(asc(orders.createdAt), asc(orders.id), asc(orderLines.id));
+
+    const grouped = new Map<
+      string,
+      {
+        createdAt: string;
+        customer: { id: string; name: string; orgId: string };
+        deletedAt: string | null;
+        id: string;
+        orderLines: Array<{
+          id: string;
+          product: { category: string; id: string; label: string; name: string; sku: string };
+          quantity: number;
+        }>;
+        reference: string;
+        status: string;
+        totalAmount: number;
+      }
+    >();
+
+    for (const row of joinedRows) {
+      const current = grouped.get(row.orderId) ?? {
+        createdAt: row.orderCreatedAt,
+        customer: {
+          id: row.customerId,
+          name: row.customerName,
+          orgId: row.customerOrgId,
+        },
+        deletedAt: row.orderDeletedAt,
+        id: row.orderId,
+        orderLines: [],
+        reference: row.orderReference,
+        status: row.orderStatus,
+        totalAmount: row.orderTotalAmount,
+      };
+
+      if (row.lineId && row.productId) {
+        current.orderLines.push({
+          id: row.lineId,
+          product: {
+            category: row.productCategory ?? "",
+            id: row.productId,
+            label: row.productLabel ?? "",
+            name: row.productName ?? "",
+            sku: row.productSku ?? "",
+          },
+          quantity: row.quantity ?? 0,
+        });
+      }
+
+      grouped.set(row.orderId, current);
+    }
+
+    const orderIndex = new Map(orderIds.map((id, index) => [id, index]));
+    return [...grouped.values()].sort(
+      (left, right) => (orderIndex.get(left.id) ?? 0) - (orderIndex.get(right.id) ?? 0),
+    );
+  }
+
+  type PlaygroundRow = Awaited<ReturnType<typeof fetchRowsByIds>>[number];
+  const engine = createQueryEngine({
+    db: db as never,
+    schema,
+    relations,
+  }).withContext<typeof playgroundContext>();
+
+  const resource = (engine as any).defineResource("orders", {
+    relations: {
+      customer: true,
+      orderLines: {
+        with: {
+          product: true,
+        },
+      },
+    },
+    query: {
+      defaults: {
+        pagination: { pageSize: 5 },
+      },
+      facets: {
+        allowed: ["status", "customer.name", "orderLines.product.category"],
+      },
+      filters: {
+        disabled: ["deletedAt"],
+      },
+      scope: (
+        filters: ReturnType<typeof createQueryFilterBuilder>,
+        context: typeof playgroundContext,
+      ) => filters.is("customer.orgId", context.orgId),
+      search: {
+        allowed: [
+          "reference",
+          "customer.name",
+          "orderLines.product.name",
+          "orderLines.product.sku",
+        ],
+        defaults: ["reference", "customer.name"],
+      },
+      sort: {
+        defaults: [{ dir: "desc", key: "createdAt" }],
+        disabled: ["orderLines.product.name"],
+      },
+    },
+    strategy: {
+      rows: async ({ ids }: { ids: unknown[] }) => {
+        console.debug("[playground] hydrating rows with sql.js adapter", { idCount: ids.length });
+        return fetchRowsByIds(ids);
+      },
+    },
+  });
+
+  return resource as {
+    query(args: { context: typeof playgroundContext; request: PlaygroundRequest }): Promise<{
+      rowCount: number;
+      rows: PlaygroundRow[];
+      facets?: Array<{
+        key: string;
+        options: Array<{ count: number; value: unknown }>;
+        nextCursor?: string | null;
+        total?: number;
+      }>;
+    }>;
+  };
+}
+
+export async function createPlaygroundClient() {
+  const databaseUrl = playgroundDbUrl;
+  console.debug("[playground] booting sql.js playground", { databaseUrl });
+
+  const SQL = await initSqlJs({
+    locateFile: () => sqlWasmUrl,
+  });
+  const bytes = await loadDatabaseBytes(databaseUrl);
+  const sqlite = new SQL.Database(bytes);
+
+  const resource = definePlaygroundResource(sqlite);
+  console.debug("[playground] resource ready");
+
+  return {
+    dispose() {
+      console.debug("[playground] disposing sql.js database");
+      sqlite.close();
+    },
+    async run(request: PlaygroundRequest) {
+      console.debug("[playground] running request", request);
+      const result = (await resource.query({
+        context: playgroundContext,
+        request,
+      })) as Awaited<ReturnType<typeof resource.query>>;
+      console.debug("[playground] request complete", {
+        rowCount: result.rowCount,
+        pageRows: result.rows.length,
+        facetCount: result.facets?.length ?? 0,
+      });
+      return result;
+    },
+  };
+}

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -40,8 +40,8 @@ seo:
 Get started
 ::::
 
-::::u-button{color="neutral" size="xl" to="/getting-started/introduction" variant="outline"}
-Introduction
+::::u-button{color="neutral" size="xl" to="/playground" variant="outline"}
+Playground
 ::::
 
 </div>
@@ -251,10 +251,14 @@ await orders.query({
   Define your engine, add a resource, run your first query.
 </p>
 
-<div class="flex justify-center">
+<div class="flex flex-wrap justify-center gap-3">
 
 ::::u-button{color="primary" size="xl" to="/getting-started/quick-start" trailing-icon="i-lucide-arrow-right"}
 Quick Start
+::::
+
+::::u-button{color="neutral" size="xl" to="/playground" variant="outline"}
+Playground
 ::::
 
 </div>

--- a/docs/layer/app/components/app/AppHeaderCTA.vue
+++ b/docs/layer/app/components/app/AppHeaderCTA.vue
@@ -1,3 +1,18 @@
+<script setup lang="ts">
+const route = useRoute();
+
+const isPlaygroundPage = computed(() => route.path === "/playground");
+</script>
+
 <template>
-  <div />
+  <UButton
+    to="/playground"
+    icon="i-lucide-square-terminal"
+    color="neutral"
+    :variant="isPlaygroundPage ? 'soft' : 'ghost'"
+    size="sm"
+    class="hidden md:inline-flex"
+  >
+    Playground
+  </UButton>
 </template>

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,18 +7,24 @@
     "generate": "nuxt prepare && nuxt generate",
     "preview": "nuxt preview",
     "typecheck": "nuxt prepare",
+    "generate:playground-db": "node scripts/generate-playground-db.mjs",
     "twoslash:verify": "nuxt prepare && nuxt-content-twoslash verify",
     "check": "bun run build && bun run twoslash:verify"
   },
   "dependencies": {
+    "@faker-js/faker": "^10.4.0",
     "better-sqlite3": "^12.5.0",
     "docus": "latest",
     "drizzle-orm": "1.0.0-beta.16-ea816b6",
     "drizzle-resource": "workspace:*",
     "nuxt": "^4.2.2",
     "nuxt-content-twoslash": "^0.4.0",
+    "sql.js": "^1.14.1",
     "zod": "^4.3.6",
     "zod-to-json-schema": "^3.24.6"
+  },
+  "devDependencies": {
+    "@types/sql.js": "^1.4.11"
   },
   "packageManager": "bun@1.3.6"
 }

--- a/docs/scripts/generate-playground-db.mjs
+++ b/docs/scripts/generate-playground-db.mjs
@@ -1,0 +1,235 @@
+import Database from "better-sqlite3";
+import { mkdirSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const PLAYGROUND_PRODUCT_COUNT = 180;
+const PLAYGROUND_CUSTOMER_COUNT = 320;
+const PLAYGROUND_ORDER_COUNT = 10000;
+
+const PRODUCT_CATEGORIES = ["audio", "accessories", "laptops", "monitors", "networking", "storage"];
+
+function mulberry32(seed) {
+  let current = seed >>> 0;
+
+  return () => {
+    current += 0x6d2b79f5;
+    let value = Math.imul(current ^ (current >>> 15), 1 | current);
+    value ^= value + Math.imul(value ^ (value >>> 7), 61 | value);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function randomInt(random, min, max) {
+  return Math.floor(random() * (max - min + 1)) + min;
+}
+
+function randomPick(random, values) {
+  return values[randomInt(random, 0, values.length - 1)];
+}
+
+function randomUpper(random, length) {
+  const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+  let value = "";
+
+  for (let index = 0; index < length; index += 1) {
+    value += alphabet[randomInt(random, 0, alphabet.length - 1)];
+  }
+
+  return value;
+}
+
+function randomCompanyName(random, index) {
+  const prefixes = [
+    "Acme",
+    "Northstar",
+    "Vertex",
+    "Atlas",
+    "Summit",
+    "Bluebird",
+    "Harbor",
+    "Cinder",
+  ];
+  const middles = [
+    "Systems",
+    "Labs",
+    "Works",
+    "Commerce",
+    "Logistics",
+    "Industries",
+    "Supply",
+    "Dynamics",
+  ];
+  const suffixes = ["Group", "Co", "HQ", "Collective", "Partners"];
+
+  return `${randomPick(random, prefixes)} ${randomPick(random, middles)} ${randomPick(random, suffixes)} ${index + 1}`;
+}
+
+function randomProductName(random) {
+  const adjectives = [
+    "Adaptive",
+    "Precision",
+    "Modular",
+    "Compact",
+    "Wireless",
+    "Industrial",
+    "Portable",
+    "Ultra",
+  ];
+  const materials = ["Carbon", "Aluminum", "Fiber", "Steel", "Ceramic", "Composite", "Graphite"];
+  const nouns = ["Hub", "Laptop", "Headset", "Dock", "Monitor", "Router", "Array", "Keyboard"];
+
+  return `${randomPick(random, adjectives)} ${randomPick(random, materials)} ${randomPick(random, nouns)}`;
+}
+
+function sampleMany(random, values, count) {
+  const copy = [...values];
+
+  for (let index = copy.length - 1; index > 0; index -= 1) {
+    const nextIndex = randomInt(random, 0, index);
+    [copy[index], copy[nextIndex]] = [copy[nextIndex], copy[index]];
+  }
+
+  return copy.slice(0, count);
+}
+
+function createCustomers() {
+  const random = mulberry32(20260328);
+
+  return Array.from({ length: PLAYGROUND_CUSTOMER_COUNT }, (_, index) => ({
+    id: `customer_${index + 1}`,
+    name: randomCompanyName(random, index),
+    orgId: index < Math.floor(PLAYGROUND_CUSTOMER_COUNT * 0.74) ? "acme" : "globex",
+  }));
+}
+
+function createProducts() {
+  const random = mulberry32(20260329);
+
+  return Array.from({ length: PLAYGROUND_PRODUCT_COUNT }, (_, index) => {
+    const category = randomPick(random, PRODUCT_CATEGORIES);
+
+    return {
+      category,
+      id: `product_${index + 1}`,
+      label: category.charAt(0).toUpperCase() + category.slice(1),
+      name: randomProductName(random),
+      price: randomInt(random, 45, 2800),
+      sku: randomUpper(random, 10),
+    };
+  });
+}
+
+function createPlaygroundDb(filePath) {
+  rmSync(filePath, { force: true });
+  mkdirSync(dirname(filePath), { recursive: true });
+
+  const db = new Database(filePath);
+
+  db.exec(`
+    pragma journal_mode = delete;
+    create table customers (id text primary key, name text not null, org_id text not null);
+    create table products (id text primary key, category text not null, label text not null, name text not null, sku text not null);
+    create table orders (id text primary key, created_at text not null, customer_id text not null, deleted_at text, reference text not null, status text not null, total_amount integer not null);
+    create table order_lines (id text primary key, order_id text not null, product_id text not null, quantity integer not null);
+    create index idx_customers_org_id_lower on customers(lower(org_id));
+    create index idx_customers_name_lower on customers(lower(name));
+    create index idx_orders_customer_id on orders(customer_id);
+    create index idx_orders_created_at on orders(created_at);
+    create index idx_orders_status_lower on orders(lower(status));
+    create index idx_orders_reference_lower on orders(lower(reference));
+    create index idx_order_lines_order_id on order_lines(order_id);
+    create index idx_order_lines_product_id on order_lines(product_id);
+    create index idx_products_category_lower on products(lower(category));
+    create index idx_products_name_lower on products(lower(name));
+    create index idx_products_sku_lower on products(lower(sku));
+  `);
+
+  const customers = createCustomers();
+  const products = createProducts();
+  const random = mulberry32(20260330);
+  const start = new Date("2025-01-01T00:00:00.000Z").getTime();
+  const end = new Date("2026-03-20T00:00:00.000Z").getTime();
+
+  const insertCustomer = db.prepare("insert into customers (id, name, org_id) values (?, ?, ?)");
+  const insertProduct = db.prepare(
+    "insert into products (id, category, label, name, sku) values (?, ?, ?, ?, ?)",
+  );
+  const insertOrder = db.prepare(
+    "insert into orders (id, created_at, customer_id, deleted_at, reference, status, total_amount) values (?, ?, ?, ?, ?, ?, ?)",
+  );
+  const insertOrderLine = db.prepare(
+    "insert into order_lines (id, order_id, product_id, quantity) values (?, ?, ?, ?)",
+  );
+  const updateOrderTotal = db.prepare("update orders set total_amount = ? where id = ?");
+
+  const weightedStatuses = [
+    "pending",
+    "pending",
+    "pending",
+    "processing",
+    "processing",
+    "processing",
+    "shipped",
+    "shipped",
+    "shipped",
+    "shipped",
+    "shipped",
+    "shipped",
+    "cancelled",
+  ];
+
+  const transaction = db.transaction(() => {
+    for (const customer of customers) {
+      insertCustomer.run(customer.id, customer.name, customer.orgId);
+    }
+
+    for (const product of products) {
+      insertProduct.run(product.id, product.category, product.label, product.name, product.sku);
+    }
+
+    for (let orderIndex = 0; orderIndex < PLAYGROUND_ORDER_COUNT; orderIndex += 1) {
+      const customer = randomPick(random, customers);
+      const createdAt = new Date(randomInt(random, start, end)).toISOString();
+      const status = randomPick(random, weightedStatuses);
+      const deletedAt =
+        status === "cancelled" && randomInt(random, 1, 100) <= 16
+          ? new Date(
+              new Date(createdAt).getTime() + randomInt(random, 1, 12) * 86400000,
+            ).toISOString()
+          : null;
+      const lineCount = randomInt(random, 1, 5);
+      const selectedProducts = sampleMany(random, products, lineCount);
+      let totalAmount = 0;
+
+      insertOrder.run(
+        `order_${orderIndex + 1}`,
+        createdAt,
+        customer.id,
+        deletedAt,
+        `ORD-${String(orderIndex + 1).padStart(5, "0")}`,
+        status,
+        0,
+      );
+
+      selectedProducts.forEach((product, productIndex) => {
+        const quantity = randomInt(random, 1, 4);
+        totalAmount += product.price * quantity;
+        insertOrderLine.run(
+          `line_${orderIndex + 1}_${productIndex + 1}`,
+          `order_${orderIndex + 1}`,
+          product.id,
+          quantity,
+        );
+      });
+
+      updateOrderTotal.run(totalAmount, `order_${orderIndex + 1}`);
+    }
+  });
+
+  transaction();
+  db.close();
+}
+
+const outputFile = resolve(import.meta.dirname, "../app/assets/playground.sqlite");
+createPlaygroundDb(outputFile);
+console.log(`Generated ${outputFile}`);

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "bun run generate",
+  "buildCommand": "cd .. && bun run build && cd docs && bun run generate",
   "outputDirectory": ".output/public",
   "installCommand": "bun install",
   "framework": null

--- a/packages/core/src/sql.ts
+++ b/packages/core/src/sql.ts
@@ -231,6 +231,10 @@ function buildExistsCondition(
   if (!entry.isManyPath) return scalarBuilder(entry.column, condition);
 
   const manyStep = entry.relationPath[entry.firstManyIndex];
+  if (!manyStep) {
+    throw new Error(`Invalid many relation path for field "${condition.key}"`);
+  }
+
   let query: any = (db as any)
     .select({ one: sql<number>`1` })
     .from((schema as any)[manyStep.targetTableName]);
@@ -242,6 +246,10 @@ function buildExistsCondition(
 
   for (let index = entry.firstManyIndex + 1; index < entry.relationPath.length; index++) {
     const step = entry.relationPath[index];
+    if (!step) {
+      throw new Error(`Invalid relation step while resolving field "${condition.key}"`);
+    }
+
     query = query.innerJoin(
       (schema as any)[step.targetTableName],
       eqColumns(step.sourceColumns as any[], step.targetColumns as any[]),
@@ -659,9 +667,12 @@ export function createQueryResourceUtils<
 
     const facetResults = await Promise.all(
       Array.from(groupedFacets.values()).map(async (group, groupIndex) => {
+        const firstGroupEntry = group[0];
+        if (!firstGroupEntry) return [];
+
         const matchingIds = (config.db as any)
           .$with(`facet_matching_ids_${groupIndex}`)
-          .as(buildMatchingIdsSelect(group[0].scopedRequest));
+          .as(buildMatchingIdsSelect(firstGroupEntry.scopedRequest));
 
         return Promise.all(
           group.map(async ({ facet }) => {
@@ -691,6 +702,10 @@ export function createQueryResourceUtils<
 
                 if (entry.isManyPath && entry.firstManyIndex === 0) {
                   const manyStep = entry.relationPath[0];
+                  if (!manyStep) {
+                    throw new Error(`Invalid many relation path for facet "${facet.key}"`);
+                  }
+
                   bucketsQuery = (config.db as any)
                     .with(matchingIds)
                     .select({

--- a/packages/core/src/sql.ts
+++ b/packages/core/src/sql.ts
@@ -565,13 +565,14 @@ export function createQueryResourceUtils<
     const countQuery: any = (config.db as any)
       .with(matchingIds)
       .select({
-        rowCount: sql<number>`count(*)::int`,
+        rowCount: sql<number>`count(*)`,
       })
       .from(matchingIds);
 
     const [{ rowCount }] = await countQuery;
+    const normalizedRowCount = Number(rowCount ?? 0);
 
-    if (rowCount === 0) {
+    if (normalizedRowCount === 0) {
       return { ids: [], rowCount: 0 };
     }
 
@@ -588,12 +589,12 @@ export function createQueryResourceUtils<
 
     const pageIds = await idsQuery;
     if (pageIds.length === 0) {
-      return { ids: [], rowCount };
+      return { ids: [], rowCount: normalizedRowCount };
     }
 
     return {
       ids: pageIds.map((row: any) => row.id),
-      rowCount,
+      rowCount: normalizedRowCount,
     };
   }
 
@@ -694,7 +695,7 @@ export function createQueryResourceUtils<
                     .with(matchingIds)
                     .select({
                       value: entry.column,
-                      count: sql<number>`count(distinct ${matchingIds.id})::int`.as("count"),
+                      count: sql<number>`count(distinct ${matchingIds.id})`.as("count"),
                     })
                     .from(matchingIds)
                     .innerJoin(
@@ -712,7 +713,7 @@ export function createQueryResourceUtils<
                     .with(matchingIds)
                     .select({
                       value: entry.column,
-                      count: sql<number>`count(distinct ${matchingIds.id})::int`.as("count"),
+                      count: sql<number>`count(distinct ${matchingIds.id})`.as("count"),
                     })
                     .from(rootTable)
                     .innerJoin(matchingIds, eq(matchingIds.id, rootTable.id));
@@ -732,7 +733,7 @@ export function createQueryResourceUtils<
               .select({
                 value: facetBuckets.value,
                 count: facetBuckets.count,
-                total: sql<number>`count(*) over ()::int`.as("total"),
+                total: sql<number>`count(*) over ()`.as("total"),
               })
               .from(facetBuckets)
               .orderBy(desc(facetBuckets.count), asc(facetBuckets.value));
@@ -753,7 +754,7 @@ export function createQueryResourceUtils<
                 .filter((row: any) => row.value !== null && row.value !== undefined)
                 .map((row: any) => ({
                   value: row.value,
-                  count: row.count,
+                  count: Number(row.count ?? 0),
                 })),
               nextCursor:
                 limit !== undefined
@@ -761,7 +762,7 @@ export function createQueryResourceUtils<
                     ? String(offset + limit)
                     : null
                   : undefined,
-              total,
+              total: Number(total),
             };
           }),
         );


### PR DESCRIPTION
## Summary
- add a real docs playground backed by a pre-seeded SQLite asset and engine-driven queries
- fix SQLite-incompatible aggregate casts in the core query SQL helpers
- improve playground discoverability with landing/header links and add changesets for release prep

## Testing
- `bun run typecheck`
- `bunx nuxi typecheck` (playground-specific errors fixed; remaining failures are pre-existing in `docs/layer`)
- browser verification on `/playground` for default requests, facets, and the nested OR example

## Notes
- the playground uses the real query engine pipeline for ids/filters/search/sort/facets and only provides a `strategy.rows` bridge because `drizzle-orm/sql-js` does not expose `db.query.*.findMany()` hydration
- the generated SQLite asset now includes indexes so nested OR demos stay responsive in `sql.js`
- `bun run docs:build` was noisy while the Nuxt dev server/content DB was active; rerun in a clean process before merging if you want a final production build pass