### PR TITLE
feat(validation): add Zod and Valibot schemas

### DIFF
--- a/.changeset/bright-lobsters-validate.md
+++ b/.changeset/bright-lobsters-validate.md
@@ -1,0 +1,5 @@
+---
+"drizzle-resource": minor
+---
+
+Add resource-derived Zod and Valibot request and response schemas, including relation-aware response validation and defensive request limits.

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@changesets/cli": "^2.31.1",
         "drizzle-orm": "1.0.0-rc.4",
         "typescript": "5.9.3",
+        "valibot": "^1.4.2",
         "vite-plus": "^0.2.7",
         "zod": "^4.4.3",
         "zod-to-json-schema": "^3.25.2",
@@ -22,6 +23,7 @@
         "@codemirror/theme-one-dark": "^6.1.3",
         "@codemirror/view": "^6.43.7",
         "@faker-js/faker": "^10.5.0",
+        "@resvg/resvg-js": "^2.6.0",
         "better-sqlite3": "^13.0.2",
         "codemirror": "^6.0.2",
         "docus": "^5.12.3",
@@ -29,7 +31,9 @@
         "drizzle-resource": "workspace:*",
         "nuxt": "^4.5.1",
         "nuxt-content-twoslash": "^0.4.0",
+        "satori": "^0.19.2",
         "sql.js": "^1.14.1",
+        "valibot": "^1.4.2",
         "vue-codemirror": "^6.1.1",
         "zod": "^4.4.3",
         "zod-to-json-schema": "^3.25.2",
@@ -56,7 +60,13 @@
       },
       "peerDependencies": {
         "drizzle-orm": ">=1.0.0-rc.4",
+        "valibot": "^1.4.2",
+        "zod": "^4.4.3",
       },
+      "optionalPeers": [
+        "valibot",
+        "zod",
+      ],
     },
     "packages/valibot": {
       "name": "@drizzle-resource/valibot",
@@ -750,6 +760,32 @@
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
+    "@resvg/resvg-js": ["@resvg/resvg-js@2.6.2", "", { "optionalDependencies": { "@resvg/resvg-js-android-arm-eabi": "2.6.2", "@resvg/resvg-js-android-arm64": "2.6.2", "@resvg/resvg-js-darwin-arm64": "2.6.2", "@resvg/resvg-js-darwin-x64": "2.6.2", "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2", "@resvg/resvg-js-linux-arm64-gnu": "2.6.2", "@resvg/resvg-js-linux-arm64-musl": "2.6.2", "@resvg/resvg-js-linux-x64-gnu": "2.6.2", "@resvg/resvg-js-linux-x64-musl": "2.6.2", "@resvg/resvg-js-win32-arm64-msvc": "2.6.2", "@resvg/resvg-js-win32-ia32-msvc": "2.6.2", "@resvg/resvg-js-win32-x64-msvc": "2.6.2" } }, "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q=="],
+
+    "@resvg/resvg-js-android-arm-eabi": ["@resvg/resvg-js-android-arm-eabi@2.6.2", "", { "os": "android", "cpu": "arm" }, "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA=="],
+
+    "@resvg/resvg-js-android-arm64": ["@resvg/resvg-js-android-arm64@2.6.2", "", { "os": "android", "cpu": "arm64" }, "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ=="],
+
+    "@resvg/resvg-js-darwin-arm64": ["@resvg/resvg-js-darwin-arm64@2.6.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A=="],
+
+    "@resvg/resvg-js-darwin-x64": ["@resvg/resvg-js-darwin-x64@2.6.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw=="],
+
+    "@resvg/resvg-js-linux-arm-gnueabihf": ["@resvg/resvg-js-linux-arm-gnueabihf@2.6.2", "", { "os": "linux", "cpu": "arm" }, "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw=="],
+
+    "@resvg/resvg-js-linux-arm64-gnu": ["@resvg/resvg-js-linux-arm64-gnu@2.6.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg=="],
+
+    "@resvg/resvg-js-linux-arm64-musl": ["@resvg/resvg-js-linux-arm64-musl@2.6.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg=="],
+
+    "@resvg/resvg-js-linux-x64-gnu": ["@resvg/resvg-js-linux-x64-gnu@2.6.2", "", { "os": "linux", "cpu": "x64" }, "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw=="],
+
+    "@resvg/resvg-js-linux-x64-musl": ["@resvg/resvg-js-linux-x64-musl@2.6.2", "", { "os": "linux", "cpu": "x64" }, "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ=="],
+
+    "@resvg/resvg-js-win32-arm64-msvc": ["@resvg/resvg-js-win32-arm64-msvc@2.6.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ=="],
+
+    "@resvg/resvg-js-win32-ia32-msvc": ["@resvg/resvg-js-win32-ia32-msvc@2.6.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w=="],
+
+    "@resvg/resvg-js-win32-x64-msvc": ["@resvg/resvg-js-win32-x64-msvc@2.6.2", "", { "os": "win32", "cpu": "x64" }, "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ=="],
+
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.1", "", { "os": "android", "cpu": "arm64" }, "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA=="],
 
     "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA=="],
@@ -873,6 +909,8 @@
     "@shikijs/vitepress-twoslash": ["@shikijs/vitepress-twoslash@4.0.2", "", { "dependencies": { "@shikijs/twoslash": "4.0.2", "floating-vue": "^5.2.2", "lz-string": "^1.5.0", "magic-string": "^0.30.21", "markdown-it": "^14.1.1", "mdast-util-from-markdown": "^2.0.3", "mdast-util-gfm": "^3.1.0", "mdast-util-to-hast": "^13.2.1", "ohash": "^2.0.11", "shiki": "4.0.2", "twoslash": "^0.3.6", "twoslash-vue": "^0.3.6", "vue": "^3.5.29" } }, "sha512-Bk01fAYDDiTffRPLHNJdNlYwzExXIVcrHUVNciD931SMlKZArvteKib6mM3mWAUhcy78RW1llT3fczjKIgQHBA=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@shuding/opentype.js": ["@shuding/opentype.js@1.4.0-beta.0", "", { "dependencies": { "fflate": "^0.7.3", "string.prototype.codepointat": "^0.2.1" }, "bin": { "ot": "bin/ot" } }, "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA=="],
 
     "@simple-git/args-pathspec": ["@simple-git/args-pathspec@1.0.3", "", {}, "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA=="],
 
@@ -1324,7 +1362,7 @@
 
     "bare-url": ["bare-url@2.4.0", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA=="],
 
-    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+    "base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.11.8", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-zAgkquC2WYF0PIc6XbNYkA2uuxxFavzgmX61R+dHDUa558V8Ejf8ozTZFR6QzM24RWu4kBcRkhJ5kpz77j9fnQ=="],
 
@@ -1369,6 +1407,8 @@
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "camelize": ["camelize@1.0.1", "", {}, "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="],
 
     "caniuse-api": ["caniuse-api@4.0.0", "", { "dependencies": { "browserslist": "^4.0.0", "caniuse-lite": "^1.0.0" } }, "sha512-B0hQ1OLyJuHTQSOWXvwibWqM6DCoqJdvBA6X1S/53bd4XU7LJ1yurIPlrsouol3mw1jh9pGI4ivubSpmJeIqCA=="],
 
@@ -1460,7 +1500,17 @@
 
     "crossws": ["crossws@0.3.5", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA=="],
 
+    "css-background-parser": ["css-background-parser@0.1.0", "", {}, "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA=="],
+
+    "css-box-shadow": ["css-box-shadow@1.0.0-3", "", {}, "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg=="],
+
+    "css-color-keywords": ["css-color-keywords@1.0.0", "", {}, "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="],
+
+    "css-gradient-parser": ["css-gradient-parser@0.0.17", "", {}, "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg=="],
+
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-to-react-native": ["css-to-react-native@3.2.0", "", { "dependencies": { "camelize": "^1.0.0", "css-color-keywords": "^1.0.0", "postcss-value-parser": "^4.0.2" } }, "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ=="],
 
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
@@ -1586,6 +1636,8 @@
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
+    "emoji-regex-xs": ["emoji-regex-xs@2.0.1", "", {}, "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g=="],
+
     "emojilib": ["emojilib@2.4.0", "", {}, "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="],
 
     "emoticon": ["emoticon@4.1.0", "", {}, "sha512-VWZfnxqwNcc51hIy/sbOdEem6D+cVtpPzEEtVAFdaas30+1dgkyaOQ4sQ6Bp0tOMqWO1v+HQfYaoodOkdhK6SQ=="],
@@ -1697,6 +1749,8 @@
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fflate": ["fflate@0.7.5", "", {}, "sha512-QieYf//cis6ywHNi5qW1+PXPQ4bC+XVJAtS4AXIML8P76GroEiOxm/oQtn1f02UkJY1+KsXMJcC+R2v/Eg4G3g=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
@@ -1833,6 +1887,8 @@
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
     "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
+
+    "hex-rgb": ["hex-rgb@4.3.0", "", {}, "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw=="],
 
     "hey-listen": ["hey-listen@1.0.8", "", {}, "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="],
 
@@ -2029,6 +2085,8 @@
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
 
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
+
+    "linebreak": ["linebreak@1.1.0", "", { "dependencies": { "base64-js": "0.0.8", "unicode-trie": "^2.0.0" } }, "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ=="],
 
     "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
 
@@ -2346,6 +2404,8 @@
 
     "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 
+    "parse-css-color": ["parse-css-color@0.2.1", "", { "dependencies": { "color-name": "^1.1.4", "hex-rgb": "^4.1.0" } }, "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg=="],
+
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
     "parse-path": ["parse-path@7.1.0", "", { "dependencies": { "protocols": "^2.0.0" } }, "sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw=="],
@@ -2602,6 +2662,8 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
+    "satori": ["satori@0.19.3", "", { "dependencies": { "@shuding/opentype.js": "1.4.0-beta.0", "css-background-parser": "^0.1.0", "css-box-shadow": "1.0.0-3", "css-gradient-parser": "^0.0.17", "css-to-react-native": "^3.0.0", "emoji-regex-xs": "^2.0.1", "escape-html": "^1.0.3", "linebreak": "^1.1.0", "parse-css-color": "^0.2.1", "postcss-value-parser": "^4.2.0", "yoga-layout": "^3.2.1" } }, "sha512-dKr8TNYSyceWqBoTHWntjy25xaiWMw5GF+f8QOqFsov9OpTswLs7xdbvZudGRp9jkzbhv/4mVjVZYFtpruGKiA=="],
+
     "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
 
     "scule": ["scule@1.3.0", "", {}, "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g=="],
@@ -2699,6 +2761,8 @@
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string.prototype.codepointat": ["string.prototype.codepointat@0.2.1", "", {}, "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
@@ -2837,6 +2901,8 @@
     "unhead": ["unhead@3.2.3", "", { "dependencies": { "hookable": "^6.1.1", "unplugin": "^3.3.0" }, "peerDependencies": { "vite": ">=6.4.2" }, "optionalPeers": ["vite"] }, "sha512-BBkKvthUOufEJzG4C4u5NCdxnGMNaQdb//oPDI8lkv/6qj0faEqnPIvIPejt3FnSE501LX25Gbe2MVgKDuFnyQ=="],
 
     "unicode-emoji-modifier-base": ["unicode-emoji-modifier-base@1.0.0", "", {}, "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g=="],
+
+    "unicode-trie": ["unicode-trie@2.0.0", "", { "dependencies": { "pako": "^0.2.5", "tiny-inflate": "^1.0.0" } }, "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ=="],
 
     "unicorn-magic": ["unicorn-magic@0.4.0", "", {}, "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw=="],
 
@@ -2999,6 +3065,8 @@
     "yjs": ["yjs@13.6.30", "", { "dependencies": { "lib0": "^0.2.99" } }, "sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "youch": ["youch@4.1.1", "", { "dependencies": { "@poppinss/colors": "^4.1.6", "@poppinss/dumper": "^0.7.0", "@speed-highlight/core": "^1.2.14", "cookie-es": "^3.0.1", "youch-core": "^0.3.3" } }, "sha512-mxW3qiSnl+GRxXsaUMzv2Mbada1Y8CDltET9UxejDQe6DBYlSekghl5U5K0ReAikcHDi0G1vKZEmmo/NWAGKLA=="],
 
@@ -3305,6 +3373,8 @@
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "buffer/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "c12/dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
 
@@ -3701,6 +3771,8 @@
     "unconfig/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
     "unconfig-core/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
+
+    "unicode-trie/pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
 
     "unimport/acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
 
@@ -4123,6 +4195,8 @@
     "archiver-utils/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "ast-kit/@babel/parser/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "bl/buffer/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 

--- a/docs/content/2.query-contract/1.request-shape.md
+++ b/docs/content/2.query-contract/1.request-shape.md
@@ -21,7 +21,7 @@ resource.query({
 });
 ```
 
-The `context` value flows into your scope function and strategy overrides. The `request` describes what the client wants: which page, in what order, with which filters, searching what.
+The server-side `context` value flows into your scope function and strategy overrides. The transport `request` describes what the client wants: which page, in what order, with which filters, searching what.
 
 ## Full type
 
@@ -42,10 +42,11 @@ type QueryRequest = {
     value: string; // the search string
     fields: string[]; // which fields to search; [] means use resource defaults
   };
-  context: Record<string, unknown>; // extra client-side context (rarely used)
   facets?: QueryFacetRequest[]; // optional: request bucket counts
 };
 ```
+
+`context` is deliberately not part of the client request body. Pass trusted tenant, user, and authorization state as the sibling `context` value on `resource.query(...)`; [request schemas](/resource-setup/validation#transport-schemas) reject a body that includes it.
 
 ## Field-by-field
 
@@ -85,7 +86,7 @@ Sorting on many-to-many relation paths forces a join that can be expensive at sc
 
 If `sorting` is empty, the resource's `sort.defaults` apply. If the resource has no sort defaults, the engine applies no ORDER BY (result order is database-defined).
 
-If a sort key is in the resource's `sort.disabled` list, it is silently dropped.
+If a sort key is in the resource's `sort.disabled` list, the request is rejected.
 
 ### `filters`
 

--- a/docs/content/3.resource-setup/7.validation.md
+++ b/docs/content/3.resource-setup/7.validation.md
@@ -1,0 +1,126 @@
+---
+title: Validation
+description: Derive strict Zod or Valibot request and response schemas from one query resource.
+---
+
+Each resource can publish a validator that accepts only its client-safe request contract. It inherits field policy, relation paths, defaults, and limits from `defineResource(...)`; the server keeps tenant and authorization context outside that payload.
+
+## Resource limits
+
+Set the broadest safe bounds on the resource. The engine enforces them even when a caller does not use a schema.
+
+```ts twoslash
+import { ordersResource } from "./twoslash-support";
+
+const maxPageSize = ordersResource.queryConfig.validation.maxPageSize;
+```
+
+Configure those bounds where the resource is defined:
+
+```ts twoslash
+import { createQueryEngine } from "drizzle-resource";
+import { db, relations, schema } from "./twoslash-support";
+
+const engine = createQueryEngine({ db, schema, relations });
+
+const orders = engine.defineResource("orders", {
+  query: {
+    validation: {
+      maxPageSize: 100,
+      maxFilterDepth: 5,
+      maxFilterNodes: 50,
+      maxFacetCount: 10,
+      maxFacetLimit: 50,
+    },
+  },
+});
+```
+
+The defaults are `100`, `5`, `50`, `10`, and `50` respectively.
+
+## Transport schemas
+
+Install the validator you use alongside Drizzle Resource:
+
+::code-group
+
+```bash [Zod]
+npm install zod
+```
+
+```bash [Valibot]
+npm install valibot
+```
+
+::
+
+Create the schema once, then parse the incoming body before calling the resource. The request body cannot provide `context`; that stays under server control.
+
+```ts twoslash
+import { requestSchema } from "drizzle-resource/zod";
+import { ordersResource } from "./twoslash-support";
+
+const parseOrdersRequest = requestSchema(ordersResource);
+
+const body = parseOrdersRequest.parse({
+  pagination: { pageIndex: 1, pageSize: 25 },
+  sorting: [{ key: "createdAt", dir: "desc" }],
+  filters: [],
+  search: { value: "ORD", fields: ["reference"] },
+});
+
+await ordersResource.query({
+  request: body,
+  context: { orgId: "acme" },
+});
+```
+
+Use `drizzle-resource/valibot` the same way with `parse(requestSchema(ordersResource), body)`.
+
+### Per-endpoint restrictions
+
+The optional second argument can only narrow the resource policy. `allow` intersects the existing fields, and every limit becomes the lower of the resource and endpoint value. It cannot expose a hidden field or raise a resource limit.
+
+```ts twoslash
+import { requestSchema } from "drizzle-resource/zod";
+import { ordersResource } from "./twoslash-support";
+
+const publicOrdersRequest = requestSchema(ordersResource, {
+  defaults: { pagination: { pageSize: 50 } },
+  limits: { maxPageSize: 50 },
+  allow: {
+    filters: ["status", "customer.name"],
+    search: ["reference"],
+    facets: ["status"],
+  },
+});
+```
+
+Default sorting is checked when the schema is created. A default that is no longer allowed throws immediately instead of leaving a route with a broken fallback.
+
+## Response schemas
+
+`responseSchema` starts with Drizzle's `createSelectSchema` for every selected table, then follows the resource's declared `relations` tree. A `one` relation is nullable and a `many` relation is an array, matching Drizzle's hydrated output.
+
+```ts twoslash
+import { responseSchema } from "drizzle-resource/zod";
+import { z } from "zod";
+import { ordersResource } from "./twoslash-support";
+
+const ordersResponse = responseSchema(ordersResource, {
+  columns: {
+    totalAmount: (schema) => schema.transform((value: unknown) => Number(value)),
+  },
+  relations: {
+    customer: {
+      columns: {
+        name: (schema) => schema.transform((value: unknown) => String(value).trim()),
+      },
+    },
+  },
+});
+
+type OrdersResponse = z.infer<typeof ordersResponse>;
+```
+
+The override changes validation and output parsing only. It does not modify the selected rows, authorization rules, or the SQL query; keep those concerns on the resource itself.

--- a/docs/content/5.reference/1.methods.md
+++ b/docs/content/5.reference/1.methods.md
@@ -20,7 +20,6 @@ const result = await ordersResource.query({
     sorting: [{ key: "createdAt", dir: "desc" }],
     search: { value: "", fields: [] },
     filters: [],
-    context: {},
     facets: [{ key: "status", mode: "exclude-self", limit: 10 }],
   },
 });

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,6 +17,7 @@
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.43.7",
     "@faker-js/faker": "^10.5.0",
+    "@resvg/resvg-js": "^2.6.0",
     "better-sqlite3": "^13.0.2",
     "codemirror": "^6.0.2",
     "docus": "^5.12.3",
@@ -24,7 +25,9 @@
     "drizzle-resource": "workspace:*",
     "nuxt": "^4.5.1",
     "nuxt-content-twoslash": "^0.4.0",
+    "satori": "^0.19.2",
     "sql.js": "^1.14.1",
+    "valibot": "^1.4.2",
     "vue-codemirror": "^6.1.1",
     "zod": "^4.4.3",
     "zod-to-json-schema": "^3.25.2"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format:check": "vp fmt --check",
     "lint": "vp lint",
     "typecheck": "vp run @drizzle-resource/core#typecheck && vp run @drizzle-resource/zod#typecheck && vp run @drizzle-resource/valibot#typecheck && vp run drizzle-resource#typecheck",
-    "test": "vp run @drizzle-resource/core#test",
+    "test": "vp run @drizzle-resource/core#test && vp run @drizzle-resource/zod#test && vp run @drizzle-resource/valibot#test",
     "build": "vp run @drizzle-resource/core#build && vp run @drizzle-resource/zod#build && vp run @drizzle-resource/valibot#build && vp run drizzle-resource#build",
     "prepare": "vp config",
     "pack:check": "vp run drizzle-resource#pack:check",
@@ -32,6 +32,7 @@
     "@changesets/cli": "^2.31.1",
     "drizzle-orm": "1.0.0-rc.4",
     "typescript": "5.9.3",
+    "valibot": "^1.4.2",
     "vite-plus": "^0.2.7",
     "zod": "^4.4.3",
     "zod-to-json-schema": "^3.25.2"

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,5 +1,6 @@
 export { createQueryEngine } from "./src/engine.js";
 export { createQueryFilterBuilder } from "./src/filters.js";
+export { defaultQueryValidation, resolveQueryRequestContract } from "./src/contracts.js";
 export type {
   DefineResourceOptions,
   DefineQueryResourceOptions,
@@ -24,6 +25,9 @@ export type {
   QueryFilterInput,
   QueryFilterNode,
   QueryRequest,
+  QueryRequestContract,
+  QueryRequestInput,
+  QueryRequestSchemaOverride,
   QuerySortDescriptor,
   QuerySorting,
   ResourceQueryConfig,
@@ -32,6 +36,7 @@ export type {
   ResourceQueryFiltersConfig,
   ResourceQuerySearchConfig,
   ResourceQuerySortConfig,
+  ResourceQueryValidationConfig,
   ResourceQueryStrategyConfig,
   QueryResource,
   QueryResourceUtils,

--- a/packages/core/src/contracts.ts
+++ b/packages/core/src/contracts.ts
@@ -1,0 +1,84 @@
+import type {
+  QueryRequestContract,
+  QueryRequestSchemaOverride,
+  QueryResource,
+  ResourceQueryDefaultsConfig,
+  ResourceQueryValidationConfig,
+} from "./types.js";
+
+export const defaultQueryValidation: Required<ResourceQueryValidationConfig> = {
+  maxPageSize: 100,
+  maxFilterDepth: 5,
+  maxFilterNodes: 50,
+  maxFacetCount: 10,
+  maxFacetLimit: 50,
+};
+
+function resolveLimits(
+  resourceLimits: Required<ResourceQueryValidationConfig>,
+  override?: ResourceQueryValidationConfig,
+): Required<ResourceQueryValidationConfig> {
+  return {
+    maxPageSize: Math.min(resourceLimits.maxPageSize, override?.maxPageSize ?? Infinity),
+    maxFilterDepth: Math.min(resourceLimits.maxFilterDepth, override?.maxFilterDepth ?? Infinity),
+    maxFilterNodes: Math.min(resourceLimits.maxFilterNodes, override?.maxFilterNodes ?? Infinity),
+    maxFacetCount: Math.min(resourceLimits.maxFacetCount, override?.maxFacetCount ?? Infinity),
+    maxFacetLimit: Math.min(resourceLimits.maxFacetLimit, override?.maxFacetLimit ?? Infinity),
+  };
+}
+
+function restrict<T extends string>(base: Iterable<T>, allowed?: readonly string[]): Set<T> {
+  const baseSet = new Set(base);
+  return allowed === undefined
+    ? baseSet
+    : new Set(allowed.filter((field): field is T => baseSet.has(field as T)));
+}
+
+function mergeDefaults(
+  defaults: ResourceQueryDefaultsConfig,
+  override?: ResourceQueryDefaultsConfig,
+): ResourceQueryDefaultsConfig {
+  return {
+    ...defaults,
+    ...override,
+    pagination: {
+      ...defaults.pagination,
+      ...override?.pagination,
+    },
+    sorting: override?.sorting ?? defaults.sorting,
+  };
+}
+
+/** Resolve the validator-facing contract for a resource without widening its policy. */
+export function resolveQueryRequestContract(
+  resource: QueryResource<any, any, any, any, any, any, any>,
+  override?: QueryRequestSchemaOverride,
+): QueryRequestContract {
+  const filters = restrict(resource.fields.keys(), override?.allow?.filters);
+  const sorting = restrict(
+    Array.from(resource.fields.values())
+      .filter((entry) => entry.sortable)
+      .map((entry) => entry.path),
+    override?.allow?.sorting,
+  );
+  const search = restrict(resource.queryConfig.search.allowed, override?.allow?.search);
+  const facets = restrict(resource.queryConfig.facets.allowed, override?.allow?.facets);
+  const defaults = mergeDefaults(resource.queryConfig.defaults, override?.defaults);
+
+  for (const descriptor of defaults.sorting ?? []) {
+    if (!sorting.has(descriptor.key)) {
+      throw new Error(
+        `Default sorting field "${descriptor.key}" is not allowed for resource "${String(resource.key)}"`,
+      );
+    }
+  }
+
+  return {
+    filters,
+    sorting,
+    search,
+    facets,
+    defaults,
+    limits: resolveLimits(resource.queryConfig.validation, override?.limits),
+  };
+}

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -7,6 +7,7 @@ import type {
   QueryFacetRequest,
   QueryFilterNode,
   QueryRequest,
+  QueryRequestInput,
   QueryRelationsConfig,
   QueryResultRowShape,
   QueryResponse,
@@ -15,9 +16,10 @@ import type {
 } from "./types.js";
 import { buildFieldRegistry, createQueryResourceUtils, mergeScopeFilters } from "./sql.js";
 import { createQueryFilterBuilder } from "./filters.js";
+import { defaultQueryValidation } from "./contracts.js";
 
 function normalizeRequest(
-  request: QueryRequest,
+  request: QueryRequestInput,
   defaultSearchFields: readonly string[],
   defaults?: {
     pagination?: Partial<QueryRequest["pagination"]>;
@@ -32,6 +34,7 @@ function normalizeRequest(
 
   return {
     ...request,
+    context: {},
     pagination: {
       pageIndex: request.pagination.pageIndex > 0 ? request.pagination.pageIndex : defaultPageIndex,
       pageSize: request.pagination.pageSize > 0 ? request.pagination.pageSize : defaultPageSize,
@@ -44,6 +47,46 @@ function normalizeRequest(
   };
 }
 
+function assertRequestLimits(
+  request: QueryRequest,
+  limits: {
+    maxPageSize: number;
+    maxFilterDepth: number;
+    maxFilterNodes: number;
+    maxFacetCount: number;
+    maxFacetLimit: number;
+  },
+) {
+  if (request.pagination.pageSize > limits.maxPageSize) {
+    throw new Error(`Page size cannot exceed ${limits.maxPageSize}`);
+  }
+
+  let filterNodes = 0;
+  const stack = request.filters.map((node) => ({ node, depth: 1 }));
+  while (stack.length > 0) {
+    const { node, depth } = stack.pop()!;
+    filterNodes += 1;
+    if (filterNodes > limits.maxFilterNodes) {
+      throw new Error(`Filter tree cannot exceed ${limits.maxFilterNodes} nodes`);
+    }
+    if (depth > limits.maxFilterDepth) {
+      throw new Error(`Filter tree cannot exceed ${limits.maxFilterDepth} levels`);
+    }
+    if (node.type === "group") {
+      stack.push(...node.children.map((child) => ({ node: child, depth: depth + 1 })));
+    }
+  }
+
+  if ((request.facets?.length ?? 0) > limits.maxFacetCount) {
+    throw new Error(`A request cannot contain more than ${limits.maxFacetCount} facets`);
+  }
+  for (const facet of request.facets ?? []) {
+    if ((facet.limit ?? 0) > limits.maxFacetLimit) {
+      throw new Error(`Facet limit cannot exceed ${limits.maxFacetLimit}`);
+    }
+  }
+}
+
 function assertKnownFields(
   resource: QueryResource<any, any, any, any, any, any, any>,
   request: QueryRequest,
@@ -52,6 +95,13 @@ function assertKnownFields(
   if (invalidSort) {
     throw new Error(
       `Unknown sorting field "${invalidSort.key}" for resource "${String(resource.key)}"`,
+    );
+  }
+
+  const disabledSort = request.sorting.find(({ key }) => !resource.fields.get(key)?.sortable);
+  if (disabledSort) {
+    throw new Error(
+      `Sorting field "${disabledSort.key}" is not allowed for resource "${String(resource.key)}"`,
     );
   }
 
@@ -101,6 +151,7 @@ async function executeFacetsForResource(
   facets: QueryFacetRequest[],
   context?: unknown,
 ): Promise<QueryFacetsResponse> {
+  assertRequestLimits(request, resource.queryConfig.validation);
   assertKnownFacetFields(resource, facets);
 
   if (options.strategy?.facets) {
@@ -239,6 +290,8 @@ export function createQueryEngine<
 
       const resource: QueryResource<any, any, any, any, any, any, any> = {
         key: root,
+        schema: config.schema,
+        relationGraph: config.relations,
         relations: relationsClause,
         fields: fieldRegistry,
         queryConfig: {
@@ -260,12 +313,24 @@ export function createQueryEngine<
             pagination: options.query?.defaults?.pagination,
             sorting: options.query?.sort?.defaults,
           },
+          validation: {
+            maxPageSize:
+              options.query?.validation?.maxPageSize ?? defaultQueryValidation.maxPageSize,
+            maxFilterDepth:
+              options.query?.validation?.maxFilterDepth ?? defaultQueryValidation.maxFilterDepth,
+            maxFilterNodes:
+              options.query?.validation?.maxFilterNodes ?? defaultQueryValidation.maxFilterNodes,
+            maxFacetCount:
+              options.query?.validation?.maxFacetCount ?? defaultQueryValidation.maxFacetCount,
+            maxFacetLimit:
+              options.query?.validation?.maxFacetLimit ?? defaultQueryValidation.maxFacetLimit,
+          },
         },
         query: async ({
           request,
           context,
         }: {
-          request: QueryRequest;
+          request: QueryRequestInput;
           context?: any;
         }): Promise<any> => {
           const normalizedRequest = prepareRequest(request, context);
@@ -322,7 +387,7 @@ export function createQueryEngine<
           request,
           context,
         }: {
-          request: QueryRequest;
+          request: QueryRequestInput;
           context?: any;
         }): Promise<any> => {
           const normalizedRequest = prepareRequest(request, context);
@@ -337,7 +402,7 @@ export function createQueryEngine<
           ids,
           context,
         }: {
-          request: QueryRequest;
+          request: QueryRequestInput;
           ids: unknown[];
           context?: any;
         }): Promise<any> => {
@@ -353,7 +418,7 @@ export function createQueryEngine<
           facets,
           context,
         }: {
-          request: QueryRequest;
+          request: QueryRequestInput;
           facets: QueryFacetRequest[];
           context?: any;
         }): Promise<any> => {
@@ -373,7 +438,7 @@ export function createQueryEngine<
         },
       };
 
-      function prepareRequest(request: QueryRequest, context: any) {
+      function prepareRequest(request: QueryRequestInput, context: any) {
         const scopedFilters = options.query?.scope?.(filterBuilder, context);
         const normalizedRequest = normalizeRequest(
           {
@@ -386,6 +451,8 @@ export function createQueryEngine<
             sorting: options.query?.sort?.defaults,
           },
         );
+
+        assertRequestLimits(normalizedRequest, resource.queryConfig.validation);
 
         assertKnownFields(
           resource as QueryResource<any, any, any, any, any, any, any>,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -156,6 +156,17 @@ export interface QueryRequest {
 }
 
 /**
+ * Client-safe request payload accepted by resource query methods.
+ *
+ * Request context belongs to the server-side `resource.query({ context })` call, so validators
+ * deliberately omit it from the transport payload.
+ */
+export type QueryRequestInput = Omit<QueryRequest, "context"> & {
+  /** @deprecated Pass trusted context through `resource.query({ context })` instead. */
+  context?: Record<string, unknown>;
+};
+
+/**
  * Result returned from `resource.query(...)`.
  */
 export interface QueryResponse<TRow = Record<string, unknown>> {
@@ -683,6 +694,37 @@ export interface ResourceQueryDefaultsConfig {
   sorting?: Readonly<QueryRequest["sorting"]>;
 }
 
+/** Upper bounds applied to every request, including requests that bypass a validator. */
+export interface ResourceQueryValidationConfig {
+  maxPageSize?: number;
+  maxFilterDepth?: number;
+  maxFilterNodes?: number;
+  maxFacetCount?: number;
+  maxFacetLimit?: number;
+}
+
+/** A validator-local restriction merged with a resource contract. */
+export interface QueryRequestSchemaOverride<TField extends string = string> {
+  defaults?: ResourceQueryDefaultsConfig;
+  limits?: ResourceQueryValidationConfig;
+  allow?: {
+    filters?: readonly TField[];
+    sorting?: readonly TField[];
+    search?: readonly TField[];
+    facets?: readonly TField[];
+  };
+}
+
+/** Fully resolved policy consumed by an integration validator. */
+export interface QueryRequestContract<TField extends string = string> {
+  filters: Set<TField>;
+  sorting: Set<TField>;
+  search: Set<TField>;
+  facets: Set<TField>;
+  defaults: ResourceQueryDefaultsConfig;
+  limits: Required<ResourceQueryValidationConfig>;
+}
+
 /**
  * Arguments shared by `strategy.query`, `strategy.ids`, and `strategy.rows`.
  */
@@ -838,6 +880,8 @@ export interface ResourceQueryConfig<
    * Request defaults applied before strategies run.
    */
   defaults?: ResourceQueryDefaultsConfig;
+  /** Defensive limits for request complexity and result size. */
+  validation?: ResourceQueryValidationConfig;
 }
 
 export interface ResourceRuntimeQueryConfig<TField extends string> {
@@ -856,6 +900,7 @@ export interface ResourceRuntimeQueryConfig<TField extends string> {
     allowed: Set<TField>;
   };
   defaults: ResourceQueryDefaultsConfig;
+  validation: Required<ResourceQueryValidationConfig>;
 }
 
 export interface QueryResource<
@@ -871,6 +916,10 @@ export interface QueryResource<
    * Root table key registered for this resource.
    */
   key: TRoot;
+  /** Drizzle schema used to derive this resource's row shape. */
+  schema: TSchema;
+  /** Drizzle relation graph used to derive selected nested row shapes. */
+  relationGraph: TRelations;
   /**
    * Drizzle relational `with` tree used for default row hydration.
    */
@@ -887,21 +936,21 @@ export interface QueryResource<
    * Resolve a page of rows, count, and optionally facets.
    */
   query: <TContextOverride extends TContext = TContext>(args: {
-    request: QueryRequest;
+    request: QueryRequestInput;
     context?: TContextOverride;
   }) => Promise<QueryResponse<TRow>>;
   /**
    * Resolve ordered IDs and total count without row hydration.
    */
   queryIds: <TContextOverride extends TContext = TContext>(args: {
-    request: QueryRequest;
+    request: QueryRequestInput;
     context?: TContextOverride;
   }) => Promise<QueryIdsResponse<TRow extends { id: infer TId } ? TId : unknown>>;
   /**
    * Hydrate rows for a known ordered ID list.
    */
   queryRows: <TContextOverride extends TContext = TContext>(args: {
-    request: QueryRequest;
+    request: QueryRequestInput;
     ids: Array<TRow extends { id: infer TId } ? TId : unknown>;
     context?: TContextOverride;
   }) => Promise<TRow[]>;
@@ -912,7 +961,7 @@ export interface QueryResource<
     TFacetKey extends string = string,
     TContextOverride extends TContext = TContext,
   >(args: {
-    request: QueryRequest;
+    request: QueryRequestInput;
     facets: QueryFacetRequest<TFacetKey>[];
     context?: TContextOverride;
   }) => Promise<QueryFacetsResponse<TFacetKey>>;

--- a/packages/core/tests/query-resource.test.ts
+++ b/packages/core/tests/query-resource.test.ts
@@ -533,6 +533,7 @@ describe("defineResource", () => {
       resource.query({
         request: {
           ...baseRequest,
+          pagination: { pageIndex: 1, pageSize: 10 },
           filters: [
             {
               type: "condition",
@@ -600,6 +601,7 @@ describe("defineResource", () => {
       resource.query({
         request: {
           ...baseRequest,
+          pagination: { pageIndex: 1, pageSize: 10 },
           filters: [
             {
               type: "condition",
@@ -611,6 +613,49 @@ describe("defineResource", () => {
         },
       }),
     ).rejects.toThrow('Unknown filter field "email" for resource "employees"');
+  });
+
+  it("enforces configured request limits even without an integration schema", async () => {
+    const resource = createQueryEngine({
+      db: { query: { employees: { findMany: async () => [] } } },
+      schema,
+      relations,
+    }).defineResource("employees", {
+      query: {
+        validation: { maxPageSize: 10, maxFilterDepth: 1, maxFacetLimit: 5 },
+      },
+      strategy: {
+        query: async () => ({ rows: [], rowCount: 0 }),
+      },
+    });
+
+    await expect(
+      resource.query({ request: { ...baseRequest, pagination: { pageIndex: 1, pageSize: 11 } } }),
+    ).rejects.toThrow("Page size cannot exceed 10");
+    await expect(
+      resource.query({
+        request: {
+          ...baseRequest,
+          pagination: { pageIndex: 1, pageSize: 10 },
+          filters: [
+            {
+              type: "group",
+              combinator: "and",
+              children: [{ type: "group", combinator: "and", children: [] }],
+            },
+          ],
+        },
+      }),
+    ).rejects.toThrow("Filter tree cannot exceed 1 levels");
+    await expect(
+      resource.query({
+        request: {
+          ...baseRequest,
+          pagination: { pageIndex: 1, pageSize: 10 },
+          facets: [{ key: "fullName", limit: 6 }],
+        },
+      }),
+    ).rejects.toThrow("Facet limit cannot exceed 5");
   });
 
   it("skips the facet strategy when the main query strategy already returns facets", async () => {

--- a/packages/drizzle-resource/package.json
+++ b/packages/drizzle-resource/package.json
@@ -60,6 +60,16 @@
     "drizzle-orm": "1.0.0-rc.4"
   },
   "peerDependencies": {
-    "drizzle-orm": ">=1.0.0-rc.4"
+    "drizzle-orm": ">=1.0.0-rc.4",
+    "valibot": "^1.4.2",
+    "zod": "^4.4.3"
+  },
+  "peerDependenciesMeta": {
+    "valibot": {
+      "optional": true
+    },
+    "zod": {
+      "optional": true
+    }
   }
 }

--- a/packages/drizzle-resource/vite.config.ts
+++ b/packages/drizzle-resource/vite.config.ts
@@ -22,6 +22,9 @@ export default defineConfig({
   },
   pack: {
     clean: true,
+    deps: {
+      neverBundle: ["drizzle-orm", "drizzle-orm/zod", "drizzle-orm/valibot", "valibot", "zod"],
+    },
     dts: {
       oxc: true,
     },

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "typecheck": "vp check",
+    "test": "vp test",
     "build": "vp pack",
     "check": "vp check && vp pack"
   }

--- a/packages/valibot/src/index.ts
+++ b/packages/valibot/src/index.ts
@@ -1,7 +1,254 @@
-export interface QueryValibotIntegrationConfig {
-  readonly package: "valibot";
+import { createSelectSchema } from "drizzle-orm/valibot";
+import * as v from "valibot";
+
+export type QueryValibotIntegrationConfig = { readonly package: "valibot" };
+
+export const queryValibotIntegration: QueryValibotIntegrationConfig = { package: "valibot" };
+
+export interface QueryResponseSchemaOverride {
+  columns?: Record<string, (schema: any) => any>;
+  relations?: Record<string, QueryResponseSchemaOverride>;
 }
 
-export const queryValibotIntegration: QueryValibotIntegrationConfig = {
-  package: "valibot",
-};
+interface QueryRequestSchemaOverride {
+  defaults?: { pagination?: { pageIndex?: number; pageSize?: number }; sorting?: readonly any[] };
+  limits?: Partial<ReturnType<typeof defaultLimits>>;
+  allow?: Partial<Record<"filters" | "sorting" | "search" | "facets", readonly string[]>>;
+}
+
+const defaultLimits = () => ({
+  maxPageSize: 100,
+  maxFilterDepth: 5,
+  maxFilterNodes: 50,
+  maxFacetCount: 10,
+  maxFacetLimit: 50,
+});
+
+function resolveQueryRequestContract(resource: any, override?: QueryRequestSchemaOverride) {
+  const restrict = (base: Iterable<string>, allow?: readonly string[]) => {
+    const fields = new Set(base);
+    return allow === undefined ? fields : new Set(allow.filter((field) => fields.has(field)));
+  };
+  const defaults = {
+    ...resource.queryConfig.defaults,
+    ...override?.defaults,
+    pagination: {
+      ...resource.queryConfig.defaults.pagination,
+      ...override?.defaults?.pagination,
+    },
+    sorting: override?.defaults?.sorting ?? resource.queryConfig.defaults.sorting,
+  };
+  const contract = {
+    filters: restrict(resource.fields.keys(), override?.allow?.filters),
+    sorting: restrict(
+      Array.from(resource.fields.values())
+        .filter((entry: any) => entry.sortable)
+        .map((entry: any) => entry.path),
+      override?.allow?.sorting,
+    ),
+    search: restrict(resource.queryConfig.search.allowed, override?.allow?.search),
+    facets: restrict(resource.queryConfig.facets.allowed, override?.allow?.facets),
+    defaults,
+    limits: Object.fromEntries(
+      Object.entries(defaultLimits()).map(([key, fallback]) => [
+        key,
+        Math.min(
+          resource.queryConfig.validation?.[key] ?? fallback,
+          override?.limits?.[key as keyof typeof override.limits] ?? Infinity,
+        ),
+      ]),
+    ) as ReturnType<typeof defaultLimits>,
+  };
+
+  for (const descriptor of contract.defaults.sorting ?? []) {
+    if (!contract.sorting.has(descriptor.key)) {
+      throw new Error(
+        `Default sorting field "${descriptor.key}" is not allowed for resource "${String(resource.key)}"`,
+      );
+    }
+  }
+  return contract;
+}
+
+function allowedString(values: Set<string>, label: string) {
+  return v.pipe(
+    v.string(),
+    v.check((value) => values.has(value), `${label} is not allowed`),
+  );
+}
+
+function hasAllowedFilterDepth(filters: any[], maxDepth: number) {
+  const stack = filters.map((filter) => ({ filter, depth: 1 }));
+  while (stack.length > 0) {
+    const { filter, depth } = stack.pop()!;
+    if (depth > maxDepth) return false;
+    if (filter.type === "group") {
+      stack.push(...filter.children.map((child) => ({ filter: child, depth: depth + 1 })));
+    }
+  }
+  return true;
+}
+
+function responseRowSchema(
+  resource: any,
+  tableName: string,
+  withClause: Record<string, unknown> | undefined,
+  override?: QueryResponseSchemaOverride,
+): any {
+  const table = resource.schema[tableName];
+  if (!table) throw new Error(`Unknown table "${tableName}" in resource response schema`);
+
+  const base = createSelectSchema(table, override?.columns) as any;
+  const entries = { ...base.entries } as Record<string, any>;
+  const relations = resource.relationGraph[tableName]?.relations ?? {};
+
+  for (const [relationName, relationConfig] of Object.entries(withClause ?? {})) {
+    const relation = relations[relationName];
+    if (!relation) throw new Error(`Unknown relation "${relationName}" on table "${tableName}"`);
+    const nestedWith =
+      relationConfig && typeof relationConfig === "object" && "with" in relationConfig
+        ? ((relationConfig as { with?: Record<string, unknown> }).with ?? undefined)
+        : undefined;
+    const nested = responseRowSchema(
+      resource,
+      relation.targetTableName,
+      nestedWith,
+      override?.relations?.[relationName],
+    );
+    entries[relationName] = relation.relationType === "many" ? v.array(nested) : v.nullable(nested);
+  }
+
+  return v.object(entries);
+}
+
+/** Build a strict transport schema from a resource's request contract. */
+export function requestSchema(resource: any, override?: QueryRequestSchemaOverride): any {
+  const contract = resolveQueryRequestContract(resource, override);
+  const filter: any = v.lazy(() =>
+    v.variant("type", [
+      v.strictObject({
+        type: v.literal("condition"),
+        key: allowedString(contract.filters, "Filter field"),
+        operator: v.picklist([
+          "contains",
+          "is",
+          "isAnyOf",
+          "isNot",
+          "gt",
+          "gte",
+          "lt",
+          "lte",
+          "between",
+          "before",
+          "after",
+        ]),
+        value: v.unknown(),
+      }),
+      v.strictObject({
+        type: v.literal("group"),
+        combinator: v.picklist(["and", "or"]),
+        children: v.array(filter),
+      }),
+    ]),
+  );
+  const defaultPageIndex = contract.defaults.pagination?.pageIndex ?? 1;
+  const defaultPageSize = contract.defaults.pagination?.pageSize ?? 25;
+  const defaultSorting = [...(contract.defaults.sorting ?? [])];
+  const defaultSearchFields = [...resource.queryConfig.search.defaults].filter((field) =>
+    contract.search.has(field),
+  );
+
+  return v.strictObject({
+    pagination: v.optional(
+      v.strictObject({
+        pageIndex: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1)), defaultPageIndex),
+        pageSize: v.optional(
+          v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(contract.limits.maxPageSize)),
+          defaultPageSize,
+        ),
+      }),
+      { pageIndex: defaultPageIndex, pageSize: defaultPageSize },
+    ),
+    sorting: v.optional(
+      v.pipe(
+        v.array(
+          v.strictObject({
+            key: allowedString(contract.sorting, "Sorting field"),
+            dir: v.picklist(["asc", "desc"]),
+          }),
+        ),
+        v.transform((value) => (value.length > 0 ? value : defaultSorting)),
+      ),
+      defaultSorting,
+    ),
+    filters: v.optional(
+      v.pipe(
+        v.array(filter),
+        v.maxLength(contract.limits.maxFilterNodes),
+        v.check(
+          (value) => hasAllowedFilterDepth(value, contract.limits.maxFilterDepth),
+          `Filter tree cannot exceed ${contract.limits.maxFilterDepth} levels`,
+        ),
+      ),
+      [],
+    ),
+    search: v.optional(
+      v.strictObject({
+        value: v.optional(v.string(), ""),
+        fields: v.optional(
+          v.pipe(
+            v.array(allowedString(contract.search, "Search field")),
+            v.transform((value) => (value.length > 0 ? value : defaultSearchFields)),
+          ),
+          defaultSearchFields,
+        ),
+      }),
+      { value: "", fields: defaultSearchFields },
+    ),
+    facets: v.optional(
+      v.pipe(
+        v.array(
+          v.strictObject({
+            key: allowedString(contract.facets, "Facet field"),
+            mode: v.optional(v.picklist(["exclude-self", "include-self"])),
+            search: v.optional(v.string()),
+            limit: v.optional(
+              v.pipe(
+                v.number(),
+                v.integer(),
+                v.minValue(1),
+                v.maxValue(contract.limits.maxFacetLimit),
+              ),
+            ),
+            cursor: v.optional(v.nullable(v.string())),
+          }),
+        ),
+        v.maxLength(contract.limits.maxFacetCount),
+      ),
+    ),
+  });
+}
+
+/** Build a response schema from Drizzle select schemas and the resource relation tree. */
+export function responseSchema(resource: any, override?: QueryResponseSchemaOverride): any {
+  const row = responseRowSchema(resource, String(resource.key), resource.relations, override);
+  return v.strictObject({
+    rows: v.array(row),
+    rowCount: v.pipe(v.number(), v.integer(), v.minValue(0)),
+    facets: v.optional(
+      v.array(
+        v.strictObject({
+          key: v.string(),
+          options: v.array(
+            v.strictObject({
+              value: v.unknown(),
+              count: v.pipe(v.number(), v.integer(), v.minValue(0)),
+            }),
+          ),
+          nextCursor: v.optional(v.nullable(v.string())),
+          total: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0))),
+        }),
+      ),
+    ),
+  });
+}

--- a/packages/valibot/tests/schemas.test.ts
+++ b/packages/valibot/tests/schemas.test.ts
@@ -1,0 +1,85 @@
+import { defineRelationsPart } from "drizzle-orm";
+import { pgTable, uuid, varchar } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vite-plus/test";
+import * as v from "valibot";
+import { createQueryEngine } from "../../core/index.js";
+
+import { requestSchema, responseSchema } from "../index.js";
+
+const customers = pgTable("customers", {
+  id: uuid().primaryKey(),
+  name: varchar({ length: 255 }).notNull(),
+});
+const orders = pgTable("orders", {
+  id: uuid().primaryKey(),
+  customerId: uuid()
+    .notNull()
+    .references(() => customers.id),
+  reference: varchar({ length: 255 }).notNull(),
+});
+const schema = { customers, orders };
+const relations = defineRelationsPart(
+  schema,
+  ({ customers: customersTable, orders: ordersTable, many, one }) => ({
+    customers: { orders: many.orders({ from: customersTable.id, to: ordersTable.customerId }) },
+    orders: {
+      customer: one.customers({
+        from: ordersTable.customerId,
+        to: customersTable.id,
+        optional: false,
+      }),
+    },
+  }),
+);
+const resource = createQueryEngine({
+  db: { query: { orders: { findMany: async () => [] } } },
+  schema,
+  relations,
+}).defineResource("orders", {
+  relations: { customer: true },
+  query: { search: { allowed: ["reference"] }, validation: { maxPageSize: 75 } },
+});
+
+describe("Valibot schemas", () => {
+  it("rejects context and values outside the narrowed request contract", () => {
+    const request = requestSchema(resource, { limits: { maxPageSize: 25, maxFilterDepth: 1 } });
+    expect(v.safeParse(request, { pagination: { pageIndex: 1, pageSize: 25 } }).success).toBe(true);
+    expect(v.safeParse(request, { pagination: { pageIndex: 1, pageSize: 26 } }).success).toBe(
+      false,
+    );
+    expect(v.safeParse(request, { context: { orgId: "acme" } }).success).toBe(false);
+    expect(
+      v.safeParse(request, {
+        filters: [
+          {
+            type: "group",
+            combinator: "and",
+            children: [{ type: "group", combinator: "and", children: [] }],
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("uses Drizzle column schemas and selected relation cardinality", () => {
+    const responseContract = responseSchema(resource, {
+      columns: { reference: () => v.pipe(v.string(), v.toUpperCase()) },
+    });
+    const response = v.parse(responseContract, {
+      rows: [
+        {
+          id: "018f2d22-2580-7c0b-8a9b-2195a619d8d4",
+          customerId: "018f2d22-2580-7c0b-8a9b-2195a619d8d5",
+          reference: "ord-1",
+          customer: { id: "018f2d22-2580-7c0b-8a9b-2195a619d8d5", name: "Ada" },
+        },
+      ],
+      rowCount: 1,
+    });
+
+    expect(response.rows[0]?.reference).toBe("ORD-1");
+    expect(v.safeParse(responseContract, { rows: [{ id: "bad" }], rowCount: 1 }).success).toBe(
+      false,
+    );
+  });
+});

--- a/packages/valibot/vite.config.ts
+++ b/packages/valibot/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from "vite-plus";
 
 export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
   pack: {
     clean: true,
+    deps: {
+      neverBundle: ["drizzle-orm", "drizzle-orm/valibot", "valibot"],
+    },
     dts: {
       oxc: true,
     },

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "typecheck": "vp check",
+    "test": "vp test",
     "build": "vp pack",
     "check": "vp check && vp pack"
   }

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1,7 +1,230 @@
-export interface QueryZodIntegrationConfig {
-  readonly package: "zod";
+import { createSelectSchema } from "drizzle-orm/zod";
+import { z } from "zod";
+
+export type QueryZodIntegrationConfig = { readonly package: "zod" };
+
+export const queryZodIntegration: QueryZodIntegrationConfig = { package: "zod" };
+
+export interface QueryResponseSchemaOverride {
+  columns?: Record<string, (schema: any) => any>;
+  relations?: Record<string, QueryResponseSchemaOverride>;
 }
 
-export const queryZodIntegration: QueryZodIntegrationConfig = {
-  package: "zod",
-};
+interface QueryRequestSchemaOverride {
+  defaults?: { pagination?: { pageIndex?: number; pageSize?: number }; sorting?: readonly any[] };
+  limits?: Partial<ReturnType<typeof defaultLimits>>;
+  allow?: Partial<Record<"filters" | "sorting" | "search" | "facets", readonly string[]>>;
+}
+
+const defaultLimits = () => ({
+  maxPageSize: 100,
+  maxFilterDepth: 5,
+  maxFilterNodes: 50,
+  maxFacetCount: 10,
+  maxFacetLimit: 50,
+});
+
+function resolveQueryRequestContract(resource: any, override?: QueryRequestSchemaOverride) {
+  const restrict = (base: Iterable<string>, allow?: readonly string[]) => {
+    const fields = new Set(base);
+    return allow === undefined ? fields : new Set(allow.filter((field) => fields.has(field)));
+  };
+  const defaults = {
+    ...resource.queryConfig.defaults,
+    ...override?.defaults,
+    pagination: {
+      ...resource.queryConfig.defaults.pagination,
+      ...override?.defaults?.pagination,
+    },
+    sorting: override?.defaults?.sorting ?? resource.queryConfig.defaults.sorting,
+  };
+  const contract = {
+    filters: restrict(resource.fields.keys(), override?.allow?.filters),
+    sorting: restrict(
+      Array.from(resource.fields.values())
+        .filter((entry: any) => entry.sortable)
+        .map((entry: any) => entry.path),
+      override?.allow?.sorting,
+    ),
+    search: restrict(resource.queryConfig.search.allowed, override?.allow?.search),
+    facets: restrict(resource.queryConfig.facets.allowed, override?.allow?.facets),
+    defaults,
+    limits: Object.fromEntries(
+      Object.entries(defaultLimits()).map(([key, fallback]) => [
+        key,
+        Math.min(
+          resource.queryConfig.validation?.[key] ?? fallback,
+          override?.limits?.[key as keyof typeof override.limits] ?? Infinity,
+        ),
+      ]),
+    ) as ReturnType<typeof defaultLimits>,
+  };
+
+  for (const descriptor of contract.defaults.sorting ?? []) {
+    if (!contract.sorting.has(descriptor.key)) {
+      throw new Error(
+        `Default sorting field "${descriptor.key}" is not allowed for resource "${String(resource.key)}"`,
+      );
+    }
+  }
+  return contract;
+}
+
+function allowedString(values: Set<string>, label: string) {
+  return z.string().refine((value) => values.has(value), `${label} is not allowed`);
+}
+
+function hasAllowedFilterDepth(filters: any[], maxDepth: number) {
+  const stack = filters.map((filter) => ({ filter, depth: 1 }));
+  while (stack.length > 0) {
+    const { filter, depth } = stack.pop()!;
+    if (depth > maxDepth) return false;
+    if (filter.type === "group") {
+      stack.push(...filter.children.map((child) => ({ filter: child, depth: depth + 1 })));
+    }
+  }
+  return true;
+}
+
+function responseRowSchema(
+  resource: any,
+  tableName: string,
+  withClause: Record<string, unknown> | undefined,
+  override?: QueryResponseSchemaOverride,
+): any {
+  const table = resource.schema[tableName];
+  if (!table) throw new Error(`Unknown table "${tableName}" in resource response schema`);
+
+  const base = createSelectSchema(table, override?.columns) as any;
+  const shape = { ...base.shape } as Record<string, any>;
+  const relations = resource.relationGraph[tableName]?.relations ?? {};
+
+  for (const [relationName, relationConfig] of Object.entries(withClause ?? {})) {
+    const relation = relations[relationName];
+    if (!relation) throw new Error(`Unknown relation "${relationName}" on table "${tableName}"`);
+    const nestedWith =
+      relationConfig && typeof relationConfig === "object" && "with" in relationConfig
+        ? ((relationConfig as { with?: Record<string, unknown> }).with ?? undefined)
+        : undefined;
+    const nested = responseRowSchema(
+      resource,
+      relation.targetTableName,
+      nestedWith,
+      override?.relations?.[relationName],
+    );
+    shape[relationName] = relation.relationType === "many" ? z.array(nested) : nested.nullable();
+  }
+
+  return z.object(shape);
+}
+
+/** Build a strict transport schema from a resource's request contract. */
+export function requestSchema(resource: any, override?: QueryRequestSchemaOverride): any {
+  const contract = resolveQueryRequestContract(resource, override);
+  const filter = z.lazy(() =>
+    z.discriminatedUnion("type", [
+      z.strictObject({
+        type: z.literal("condition"),
+        key: allowedString(contract.filters, "Filter field"),
+        operator: z.enum([
+          "contains",
+          "is",
+          "isAnyOf",
+          "isNot",
+          "gt",
+          "gte",
+          "lt",
+          "lte",
+          "between",
+          "before",
+          "after",
+        ]),
+        value: z.unknown(),
+      }),
+      z.strictObject({
+        type: z.literal("group"),
+        combinator: z.enum(["and", "or"]),
+        children: z.array(filter),
+      }),
+    ]),
+  );
+  const defaultPageIndex = contract.defaults.pagination?.pageIndex ?? 1;
+  const defaultPageSize = contract.defaults.pagination?.pageSize ?? 25;
+  const defaultSorting = [...(contract.defaults.sorting ?? [])];
+  const defaultSearchFields = [...resource.queryConfig.search.defaults].filter((field) =>
+    contract.search.has(field),
+  );
+
+  return z.strictObject({
+    pagination: z
+      .object({
+        pageIndex: z.number().int().positive().default(defaultPageIndex),
+        pageSize: z
+          .number()
+          .int()
+          .positive()
+          .max(contract.limits.maxPageSize)
+          .default(defaultPageSize),
+      })
+      .default({ pageIndex: defaultPageIndex, pageSize: defaultPageSize }),
+    sorting: z
+      .array(
+        z.strictObject({
+          key: allowedString(contract.sorting, "Sorting field"),
+          dir: z.enum(["asc", "desc"]),
+        }),
+      )
+      .transform((value) => (value.length > 0 ? value : defaultSorting))
+      .default(defaultSorting),
+    filters: z
+      .array(filter)
+      .max(contract.limits.maxFilterNodes)
+      .refine(
+        (value) => hasAllowedFilterDepth(value, contract.limits.maxFilterDepth),
+        `Filter tree cannot exceed ${contract.limits.maxFilterDepth} levels`,
+      )
+      .default([]),
+    search: z
+      .object({
+        value: z.string().default(""),
+        fields: z
+          .array(allowedString(contract.search, "Search field"))
+          .transform((value) => (value.length > 0 ? value : defaultSearchFields))
+          .default(defaultSearchFields),
+      })
+      .default({ value: "", fields: defaultSearchFields }),
+    facets: z
+      .array(
+        z.strictObject({
+          key: allowedString(contract.facets, "Facet field"),
+          mode: z.enum(["exclude-self", "include-self"]).optional(),
+          search: z.string().optional(),
+          limit: z.number().int().positive().max(contract.limits.maxFacetLimit).optional(),
+          cursor: z.string().nullable().optional(),
+        }),
+      )
+      .max(contract.limits.maxFacetCount)
+      .optional(),
+  });
+}
+
+/** Build a response schema from Drizzle select schemas and the resource relation tree. */
+export function responseSchema(resource: any, override?: QueryResponseSchemaOverride): any {
+  const row = responseRowSchema(resource, String(resource.key), resource.relations, override);
+  return z.strictObject({
+    rows: z.array(row),
+    rowCount: z.number().int().nonnegative(),
+    facets: z
+      .array(
+        z.strictObject({
+          key: z.string(),
+          options: z.array(
+            z.strictObject({ value: z.unknown(), count: z.number().int().nonnegative() }),
+          ),
+          nextCursor: z.string().nullable().optional(),
+          total: z.number().int().nonnegative().optional(),
+        }),
+      )
+      .optional(),
+  });
+}

--- a/packages/zod/tests/schemas.test.ts
+++ b/packages/zod/tests/schemas.test.ts
@@ -1,0 +1,101 @@
+import { defineRelationsPart } from "drizzle-orm";
+import { pgTable, uuid, varchar } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vite-plus/test";
+import { z } from "zod";
+import { createQueryEngine } from "../../core/index.js";
+
+import { requestSchema, responseSchema } from "../index.js";
+
+const customers = pgTable("customers", {
+  id: uuid().primaryKey(),
+  name: varchar({ length: 255 }).notNull(),
+});
+const orders = pgTable("orders", {
+  id: uuid().primaryKey(),
+  customerId: uuid()
+    .notNull()
+    .references(() => customers.id),
+  reference: varchar({ length: 255 }).notNull(),
+});
+const schema = { customers, orders };
+const relations = defineRelationsPart(
+  schema,
+  ({ customers: customersTable, orders: ordersTable, many, one }) => ({
+    customers: { orders: many.orders({ from: customersTable.id, to: ordersTable.customerId }) },
+    orders: {
+      customer: one.customers({
+        from: ordersTable.customerId,
+        to: customersTable.id,
+        optional: false,
+      }),
+    },
+  }),
+);
+const resource = createQueryEngine({
+  db: { query: { orders: { findMany: async () => [] } } },
+  schema,
+  relations,
+}).defineResource("orders", {
+  relations: { customer: true },
+  query: {
+    search: { allowed: ["reference"] },
+    filters: { disabled: ["customerId"] },
+    validation: { maxPageSize: 75 },
+  },
+});
+
+describe("Zod schemas", () => {
+  it("strictly validates the resource request contract and only narrows overrides", () => {
+    const request = requestSchema(resource, {
+      limits: { maxPageSize: 25, maxFilterDepth: 1 },
+      allow: { filters: ["reference"] },
+    });
+
+    expect(
+      request.safeParse({
+        pagination: { pageIndex: 1, pageSize: 25 },
+        sorting: [],
+        filters: [{ type: "condition", key: "reference", operator: "contains", value: "ORD" }],
+        search: { value: "", fields: [] },
+      }).success,
+    ).toBe(true);
+    expect(request.safeParse({ pagination: { pageIndex: 1, pageSize: 26 } }).success).toBe(false);
+    expect(request.safeParse({ context: { orgId: "acme" } }).success).toBe(false);
+    expect(
+      request.safeParse({
+        filters: [{ type: "condition", key: "customerId", operator: "is", value: "x" }],
+      }).success,
+    ).toBe(false);
+    expect(
+      request.safeParse({
+        filters: [
+          {
+            type: "group",
+            combinator: "and",
+            children: [{ type: "group", combinator: "and", children: [] }],
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("uses Drizzle column schemas and recurses through selected relations", () => {
+    const responseContract = responseSchema(resource, {
+      columns: { reference: () => z.string().transform((value) => value.toUpperCase()) },
+    });
+    const response = responseContract.parse({
+      rows: [
+        {
+          id: "018f2d22-2580-7c0b-8a9b-2195a619d8d4",
+          customerId: "018f2d22-2580-7c0b-8a9b-2195a619d8d5",
+          reference: "ord-1",
+          customer: { id: "018f2d22-2580-7c0b-8a9b-2195a619d8d5", name: "Ada" },
+        },
+      ],
+      rowCount: 1,
+    });
+
+    expect(response.rows[0]?.reference).toBe("ORD-1");
+    expect(responseContract.safeParse({ rows: [{ id: "bad" }], rowCount: 1 }).success).toBe(false);
+  });
+});

--- a/packages/zod/vite.config.ts
+++ b/packages/zod/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from "vite-plus";
 
 export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
   pack: {
     clean: true,
+    deps: {
+      neverBundle: ["drizzle-orm", "drizzle-orm/zod", "zod"],
+    },
     dts: {
       oxc: true,
     },


### PR DESCRIPTION
## What changed

Adds requestSchema and responseSchema for Zod and Valibot. Request schemas derive field policy, defaults, and safe endpoint restrictions from a resource; response schemas use Drizzle select schemas and recurse through the declared relation tree.

Core now enforces resource request limits even without an adapter, and the package declares optional Zod and Valibot peers.

## Docs

Adds a rendered Validation guide with Twoslash-verified request, narrowing, and response examples. It also removes request-body context from the contract examples; trusted context stays on the server call.

## Validation

- bun run ci
- bun run --cwd docs twoslash:verify
- Browser-checked /resource-setup/validation

## Release

Includes a minor Changeset for drizzle-resource 1.1.0.